### PR TITLE
fix: use lambda in TCICT_ASSERT_THROWS to avoid ASAN false positive

### DIFF
--- a/include/tcict/assertion.h
+++ b/include/tcict/assertion.h
@@ -60,19 +60,31 @@ struct assertion_error : std::runtime_error {
     }                                                                                              \
   } while (false)
 
+namespace tcict {
+namespace detail {
+
+// Function template implementation for TCICT_ASSERT_THROWS.
+// Using a lambda avoids ASAN false positives caused by brace-init temporaries
+// constructed inside a try-catch block within a macro expansion.
+template <typename ExType, typename F>
+void assert_throws_impl(const char* file, int line, const char* ex_name, F&& f) {
+  bool caught = false;
+  try {
+    f();
+  } catch (const ExType&) {
+    caught = true;
+  } catch (...) {
+  }
+  if (!caught) {
+    std::ostringstream oss;
+    oss << file << ":" << line << ": expected exception " << ex_name << " not thrown";
+    throw ::tcict::assertion_error(oss.str());
+  }
+}
+
+}  // namespace detail
+}  // namespace tcict
+
 /// Assert that an expression throws a specific exception type.
 #define TCICT_ASSERT_THROWS(ExType, expr)                                                          \
-  do {                                                                                             \
-    bool tcict_caught_ = false;                                                                    \
-    try {                                                                                          \
-      expr;                                                                                        \
-    } catch (const ExType&) {                                                                      \
-      tcict_caught_ = true;                                                                        \
-    } catch (...) {                                                                                \
-    }                                                                                              \
-    if (!tcict_caught_) {                                                                          \
-      std::ostringstream oss_;                                                                     \
-      oss_ << __FILE__ << ":" << __LINE__ << ": expected exception " << #ExType << " not thrown";  \
-      throw ::tcict::assertion_error(oss_.str());                                                  \
-    }                                                                                              \
-  } while (false)
+  ::tcict::detail::assert_throws_impl<ExType>(__FILE__, __LINE__, #ExType, [&]() { expr; })


### PR DESCRIPTION
## Summary

Replace the macro-only `TCICT_ASSERT_THROWS` implementation with a function template + lambda pattern.

## Problem

Brace-init temporaries (e.g., `{0, 0}`) constructed inside a try-catch block within a macro expansion trigger ASAN `container-overflow` false positives. The temporary vector's destruction after an exception poisons heap memory, causing subsequent allocations to trip ASAN.

This caused `test_replace_sub_errors` to crash, aborting the test process and skipping all subsequent tests (106 → 65 executed).

## Fix

```cpp
// Before: macro-only (ASAN false positive with brace-init)
#define TCICT_ASSERT_THROWS(ExType, expr)  \
  do { try { expr; } catch (const ExType&) { ... } } while(0)

// After: function template + lambda (brace-init safe)
template <typename ExType, typename F>
void assert_throws_impl(const char* file, int line, const char* ex_name, F&& f);

#define TCICT_ASSERT_THROWS(ExType, expr)  \
  ::tcict::detail::assert_throws_impl<ExType>(__FILE__, __LINE__, #ExType, [&]() { expr; })
```

## Test plan

- [x] `test_replace_sub_errors` passes with ASAN enabled
- [x] All 106 TCICT tests execute (previously 65 due to crash-induced abort)
- [x] 105 pass, 1 known failure (`test_trace_partial` order-0, r-ccs-cms/tensor-computing-interface-backend-cytnx#3)