### PR TITLE
fix(fixture): dispatch epsilon by real_t precision

### DIFF
--- a/include/tcict/elem_helper.h
+++ b/include/tcict/elem_helper.h
@@ -47,4 +47,11 @@ double imag_part(tci::elem_t<TenT> elem) {
   }
 }
 
+/// True when the tensor type's real_t is single-precision (float).
+/// Tests can branch on this when accumulation-heavy operations need a
+/// coarser tolerance than the fixture's default epsilon.
+template <typename TenT>
+inline constexpr bool is_single_precision_v
+    = std::is_same_v<tci::real_t<TenT>, float>;
+
 }  // namespace tcict

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -2,6 +2,9 @@
 
 #include <tci/tensor_traits.h>
 
+#include <limits>
+#include <type_traits>
+
 namespace tcict {
 
 /// Test fixture that manages a TCI context.
@@ -18,8 +21,22 @@ struct tci_test_fixture {
 
   auto& context() { return ctx; }
 
-  // NOLINTNEXTLINE(bugprone-narrowing-conversions) -- real_t is always floating-point in TCI
-  auto epsilon() -> tci::real_t<TenT> { return static_cast<tci::real_t<TenT>>(1e-10); }
+  /// Comparison tolerance sized to the element type's real precision.
+  /// The known-type branches match values empirically sufficient for the
+  /// small test fixtures in this suite; the fallback scales machine epsilon
+  /// to absorb O(N) accumulation errors for unfamiliar real_t types.
+  auto epsilon() -> tci::real_t<TenT> {
+    using real_type = tci::real_t<TenT>;
+    if constexpr (std::is_same_v<real_type, float>) {
+      return 1e-5F;
+    } else if constexpr (std::is_same_v<real_type, double>) {
+      return 1e-10;
+    } else if constexpr (std::is_same_v<real_type, long double>) {
+      return 1e-15L;
+    } else {
+      return std::numeric_limits<real_type>::epsilon() * static_cast<real_type>(100);
+    }
+  }
 };
 
 }  // namespace tcict


### PR DESCRIPTION
## Summary

- `tci_test_fixture::epsilon()` returned a hardcoded `1e-10` regardless of the element type, below the machine epsilon of `float` (~1.19e-7). Tests instantiated with `float` or `complex<float>` could not pass numerically.
- `epsilon()` now dispatches on `tci::real_t<TenT>`: `float → 1e-5F`, `double → 1e-10`, `long double → 1e-15L`, with `std::numeric_limits<real_t>::epsilon() * 100` as a fallback for unknown `real_t` types.
- Added `is_single_precision_v<TenT>` to `elem_helper.h` so tests can branch on precision when accumulation-heavy operations need coarser tolerance than the fixture default.

Closes #29.

## Test plan

- [x] cytnx downstream rebuilds cleanly with modified headers.
- [x] No regression on existing `double` / `complex<double>` tests (baseline: 133 pass / 3 fail / 1 skip, 6293/6293 assertions pass — identical to pre-change baseline; the 3 failures are pre-existing and tolerance-unrelated: two `/tmp` file I/O fixture issues and one `tci::order` check).
- [ ] Empirical `float` validation is deferred until #31 wires up exhaustive FP type testing, as the issue's "Related" note states. If `1e-5f` proves too tight for accumulation-heavy operations (contract / SVD / eig), tolerances will be loosened per-test.