### PR TITLE
fix(tests): guard imaginary-part assertions for real tensor types

### DIFF
--- a/include/tcict/elem_helper.h
+++ b/include/tcict/elem_helper.h
@@ -47,6 +47,13 @@ double imag_part(tci::elem_t<TenT> elem) {
   }
 }
 
+/// True when the tensor type's element type is complex.
+/// Tests branch on this to guard assertions that only make sense for complex
+/// elements (e.g. verifying a non-zero imaginary part).
+template <typename TenT>
+inline constexpr bool is_complex_v
+    = std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>;
+
 /// True when the tensor type's real_t is single-precision (float).
 /// Tests can branch on this when accumulation-heavy operations need a
 /// coarser tolerance than the fixture's default epsilon.

--- a/include/tcict/tests/construction.h
+++ b/include/tcict/tests/construction.h
@@ -34,7 +34,9 @@ void test_zeros(tci_test_fixture<TenT>& fix) {
     for (std::size_t j = 0; j < 3; ++j) {
       auto elem = tci::get_elem(ctx, tensor, {i, j});
       TCICT_ASSERT_CLOSE(real_part<TenT>(elem), 0.0, eps);
-      TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), 0.0, eps);
+      if constexpr (is_complex_v<TenT>) {
+        TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), 0.0, eps);
+      }
     }
   }
 }
@@ -61,7 +63,9 @@ void test_fill(tci_test_fixture<TenT>& fix) {
     for (std::size_t j = 0; j < 4; ++j) {
       auto elem = tci::get_elem(ctx, tensor, {i, j});
       TCICT_ASSERT_CLOSE(real_part<TenT>(elem), real_part<TenT>(val), eps);
-      TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), imag_part<TenT>(val), eps);
+      if constexpr (is_complex_v<TenT>) {
+        TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), imag_part<TenT>(val), eps);
+      }
     }
   }
 }
@@ -92,7 +96,9 @@ void test_eye(tci_test_fixture<TenT>& fix) {
       } else {
         TCICT_ASSERT_CLOSE(real_part<TenT>(elem), 0.0, eps);
       }
-      TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), 0.0, eps);
+      if constexpr (is_complex_v<TenT>) {
+        TCICT_ASSERT_CLOSE(imag_part<TenT>(elem), 0.0, eps);
+      }
     }
   }
 }
@@ -128,7 +134,7 @@ void test_random_inplace(tci_test_fixture<TenT>& fix) {
   auto elem_12 = tci::get_elem(ctx, tensor, {1, 2});
   TCICT_ASSERT_CLOSE(real_part<TenT>(elem_12), 5.0, eps);
 
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_00), 0.5, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_01), 1.5, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_12), 5.5, eps);
@@ -159,7 +165,7 @@ void test_random_outofplace(tci_test_fixture<TenT>& fix) {
 
   auto elem_11 = tci::get_elem(ctx, tensor, {1, 1});
   TCICT_ASSERT_CLOSE(real_part<TenT>(elem_11), 3.0, eps);
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_11), 3.5, eps);
   }
 }
@@ -186,7 +192,7 @@ void test_copy_inplace(tci_test_fixture<TenT>& fix) {
   auto val2 = tci::get_elem(ctx, b, {1, 2});
   TCICT_ASSERT_CLOSE(real_part<TenT>(val2), -5.5, eps);
 
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val1), 13.0, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val2), 7.7, eps);
   }
@@ -213,7 +219,9 @@ void test_copy_outofplace(tci_test_fixture<TenT>& fix) {
   auto val1_a = tci::get_elem(ctx, a, {0, 1, 0});
   auto val1_b = tci::get_elem(ctx, b, {0, 1, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(val1_a), real_part<TenT>(val1_b), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(val1_a), imag_part<TenT>(val1_b), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(val1_a), imag_part<TenT>(val1_b), eps);
+  }
 
   TCICT_ASSERT(tci::shape(ctx, a) == tci::shape(ctx, b));
   TCICT_ASSERT(tci::order(ctx, a) == tci::order(ctx, b));
@@ -257,7 +265,7 @@ void test_copy_single_element(tci_test_fixture<TenT>& fix) {
 
   auto val = tci::get_elem(ctx, b, {0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(val), 3.14, eps);
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val), 2.71, eps);
   }
 }
@@ -281,7 +289,7 @@ void test_copy_large(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(corner1), 1.0, eps);
 
   auto corner2 = tci::get_elem(ctx, b, {9, 9, 9});
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(corner1), 0.0, eps);
     TCICT_ASSERT_CLOSE(real_part<TenT>(corner2), 0.0, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(corner2), 1.0, eps);
@@ -385,7 +393,9 @@ void test_allocate_3d(tci_test_fixture<TenT>& fix) {
   tci::set_elem(ctx, tensor, {0, 0, 0}, val);
   auto got = tci::get_elem(ctx, tensor, {0, 0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(got), real_part<TenT>(val), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  }
 }
 
 template <typename TenT>
@@ -410,7 +420,9 @@ void test_allocate_2d(tci_test_fixture<TenT>& fix) {
   tci::set_elem(ctx, tensor, {0, 0}, val);
   auto got = tci::get_elem(ctx, tensor, {0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(got), real_part<TenT>(val), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  }
 }
 
 template <typename TenT>
@@ -434,7 +446,9 @@ void test_allocate_1d(tci_test_fixture<TenT>& fix) {
   tci::set_elem(ctx, tensor, {0}, val);
   auto got = tci::get_elem(ctx, tensor, {0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(got), real_part<TenT>(val), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
+  }
 }
 
 // --- clear ---
@@ -497,7 +511,9 @@ void test_move_inplace(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT(tci::shape(ctx, destination) == source_shape);
   auto dest_elem = tci::get_elem(ctx, destination, {0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(dest_elem), real_part<TenT>(original_elem), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(dest_elem), imag_part<TenT>(original_elem), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(dest_elem), imag_part<TenT>(original_elem), eps);
+  }
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);
@@ -524,7 +540,9 @@ void test_move_outofplace(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT(tci::shape(ctx, result) == source_shape);
   auto result_elem = tci::get_elem(ctx, result, {1, 1});
   TCICT_ASSERT_CLOSE(real_part<TenT>(result_elem), real_part<TenT>(original_elem), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(result_elem), imag_part<TenT>(original_elem), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(result_elem), imag_part<TenT>(original_elem), eps);
+  }
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);
@@ -565,9 +583,11 @@ void test_move_preserves_values(tci_test_fixture<TenT>& fix) {
   auto moved_val2 = tci::get_elem(ctx, destination, {1, 2});
 
   TCICT_ASSERT_CLOSE(real_part<TenT>(moved_val1), real_part<TenT>(val1), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(moved_val1), imag_part<TenT>(val1), eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(moved_val2), real_part<TenT>(val2), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(moved_val2), imag_part<TenT>(val2), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(moved_val1), imag_part<TenT>(val1), eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(moved_val2), imag_part<TenT>(val2), eps);
+  }
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);

--- a/include/tcict/tests/miscellaneous.h
+++ b/include/tcict/tests/miscellaneous.h
@@ -155,7 +155,7 @@ void test_convert_data_integrity(tci_test_fixture<TenT> &fix) {
   auto val2 = tci::get_elem(ctx, b, {1, 2});
   TCICT_ASSERT_CLOSE(real_part<TenT>(val2), -7.89, eps);
 
-  if constexpr (std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>) {
+  if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val1), 4.56, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val2), 0.12, eps);
   }

--- a/include/tcict/tests/read_only_getters.h
+++ b/include/tcict/tests/read_only_getters.h
@@ -81,7 +81,9 @@ void test_set_get_elem(tci_test_fixture<TenT>& fix) {
 
   auto retrieved = tci::get_elem(ctx, tensor, coord);
   TCICT_ASSERT_CLOSE(real_part<TenT>(retrieved), real_part<TenT>(expected), eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(retrieved), imag_part<TenT>(expected), eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(retrieved), imag_part<TenT>(expected), eps);
+  }
 }
 
 // --- size_bytes for small tensor ---

--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -118,9 +118,11 @@ void test_shrink_complex_values(tci_test_fixture<TenT> &fix) {
   auto e00 = tci::get_elem(ctx, output, {0, 0});
   auto e01 = tci::get_elem(ctx, output, {0, 1});
   TCICT_ASSERT_CLOSE(real_part<TenT>(e00), 1.5, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(e00), 2.5, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(e01), 3.5, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(e01), 4.5, eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(e00), 2.5, eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(e01), 4.5, eps);
+  }
 }
 
 // --- real extraction (out-of-place) ---
@@ -152,19 +154,23 @@ void test_imag_extraction(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_IMAG
   return;
 #endif
-  auto &ctx = fix.context();
-  auto eps = fix.epsilon();
-  auto tensor = tci::zeros<TenT>(ctx, {2, 2});
-  tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
-  tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.59, 0.58));
+  // Per TCI spec, tci::imag on a real tensor yields a zero tensor, so the
+  // non-zero imaginary expectations below are meaningful only for complex TenT.
+  if constexpr (is_complex_v<TenT>) {
+    auto &ctx = fix.context();
+    auto eps = fix.epsilon();
+    auto tensor = tci::zeros<TenT>(ctx, {2, 2});
+    tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
+    tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.59, 0.58));
 
-  auto imag_tensor = tci::imag(ctx, tensor);
+    auto imag_tensor = tci::imag(ctx, tensor);
 
-  using RealTenT = tci::real_ten_t<TenT>;
-  auto elem00 = tci::get_elem(ctx, imag_tensor, {0, 0});
-  auto elem11 = tci::get_elem(ctx, imag_tensor, {1, 1});
-  TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 2.71, eps);
-  TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), 0.58, eps);
+    using RealTenT = tci::real_ten_t<TenT>;
+    auto elem00 = tci::get_elem(ctx, imag_tensor, {0, 0});
+    auto elem11 = tci::get_elem(ctx, imag_tensor, {1, 1});
+    TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 2.71, eps);
+    TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), 0.58, eps);
+  }
 }
 
 // --- real and imag extraction (in-place) ---
@@ -174,25 +180,29 @@ void test_real_imag_inplace(tci_test_fixture<TenT> &fix) {
 #if defined(TCICT_SKIP_REAL) || defined(TCICT_SKIP_IMAG)
   return;
 #endif
-  auto &ctx = fix.context();
-  auto eps = fix.epsilon();
-  auto tensor = tci::zeros<TenT>(ctx, {2, 2});
-  tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(5.25, 7.75));
-  tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-2.25, -3.75));
+  // Per TCI spec, tci::imag on a real tensor yields a zero tensor; the
+  // imaginary-side expectations below assume complex input.
+  if constexpr (is_complex_v<TenT>) {
+    auto &ctx = fix.context();
+    auto eps = fix.epsilon();
+    auto tensor = tci::zeros<TenT>(ctx, {2, 2});
+    tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(5.25, 7.75));
+    tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-2.25, -3.75));
 
-  tci::real_ten_t<TenT> real_output, imag_output;
-  tci::real(ctx, tensor, real_output);
-  tci::imag(ctx, tensor, imag_output);
+    tci::real_ten_t<TenT> real_output, imag_output;
+    tci::real(ctx, tensor, real_output);
+    tci::imag(ctx, tensor, imag_output);
 
-  using RealTenT = tci::real_ten_t<TenT>;
-  TCICT_ASSERT_CLOSE(
-      real_part<RealTenT>(tci::get_elem(ctx, real_output, {0, 0})), 5.25, eps);
-  TCICT_ASSERT_CLOSE(
-      real_part<RealTenT>(tci::get_elem(ctx, real_output, {1, 1})), -2.25, eps);
-  TCICT_ASSERT_CLOSE(
-      real_part<RealTenT>(tci::get_elem(ctx, imag_output, {0, 0})), 7.75, eps);
-  TCICT_ASSERT_CLOSE(
-      real_part<RealTenT>(tci::get_elem(ctx, imag_output, {1, 1})), -3.75, eps);
+    using RealTenT = tci::real_ten_t<TenT>;
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, real_output, {0, 0})), 5.25, eps);
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, real_output, {1, 1})), -2.25, eps);
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, imag_output, {0, 0})), 7.75, eps);
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, imag_output, {1, 1})), -3.75, eps);
+  }
 }
 
 // --- cplx_conj (in-place) ---
@@ -212,23 +222,26 @@ void test_cplx_conj_inplace(tci_test_fixture<TenT> &fix) {
 
   tci::cplx_conj(ctx, tensor);
 
-  // Real parts unchanged, imaginary parts negated
+  // Real parts unchanged for both real and complex (cplx_conj on real tensors
+  // is a no-op per TCI spec); imaginary parts only exist for complex.
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 0})), 1.0,
-                     eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {0, 0})), -2.0,
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 1})), -3.0,
                      eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {0, 1})), -4.0,
-                     eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 0})), 5.0,
-                     eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {1, 0})), 6.0,
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), -7.0,
                      eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 8.0,
-                     eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {0, 0})), -2.0,
+                       eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {0, 1})), -4.0,
+                       eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {1, 0})), 6.0,
+                       eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 8.0,
+                       eps);
+  }
 }
 
 // --- cplx_conj (out-of-place) ---
@@ -247,21 +260,23 @@ void test_cplx_conj_outofplace(tci_test_fixture<TenT> &fix) {
   TenT output;
   tci::cplx_conj(ctx, input, output);
 
-  // Input unchanged
+  // Real parts hold for both real and complex (cplx_conj out-of-place is a
+  // deep copy for real tensors per TCI spec); imaginary parts only exist for
+  // complex.
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, input, {0, 0})), 3.14,
                      eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, input, {0, 0})), 2.71,
-                     eps);
-
-  // Output conjugated
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, output, {0, 0})), 3.14,
-                     eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, output, {0, 0})), -2.71,
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, output, {1, 1})), -1.41,
                      eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, output, {1, 1})), 1.73,
-                     eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, input, {0, 0})), 2.71,
+                       eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, output, {0, 0})), -2.71,
+                       eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, output, {1, 1})), 1.73,
+                       eps);
+  }
 }
 
 // --- to_cplx (out-of-place, from real type) ---
@@ -333,20 +348,25 @@ void test_to_cplx_complex_to_complex(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_TO_CPLX
   return;
 #endif
-  auto &ctx = fix.context();
-  auto eps = fix.epsilon();
-  auto tensor = tci::zeros<TenT>(ctx, {2, 2});
-  tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
-  tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.41, 1.73));
+  // For real TenT, tci::to_cplx returns cplx_ten_t<TenT> whose elements are
+  // cplx_t<TenT>; calling imag_part<TenT>(cplx_elem) would be a type error.
+  // This test therefore only runs when TenT is already complex.
+  if constexpr (is_complex_v<TenT>) {
+    auto &ctx = fix.context();
+    auto eps = fix.epsilon();
+    auto tensor = tci::zeros<TenT>(ctx, {2, 2});
+    tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
+    tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.41, 1.73));
 
-  auto result = tci::to_cplx(ctx, tensor);
+    auto result = tci::to_cplx(ctx, tensor);
 
-  auto elem00 = tci::get_elem(ctx, result, {0, 0});
-  auto elem11 = tci::get_elem(ctx, result, {1, 1});
-  TCICT_ASSERT_CLOSE(real_part<TenT>(elem00), 3.14, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(elem00), 2.71, eps);
-  TCICT_ASSERT_CLOSE(real_part<TenT>(elem11), -1.41, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(elem11), 1.73, eps);
+    auto elem00 = tci::get_elem(ctx, result, {0, 0});
+    auto elem11 = tci::get_elem(ctx, result, {1, 1});
+    TCICT_ASSERT_CLOSE(real_part<TenT>(elem00), 3.14, eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(elem00), 2.71, eps);
+    TCICT_ASSERT_CLOSE(real_part<TenT>(elem11), -1.41, eps);
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(elem11), 1.73, eps);
+  }
 }
 
 // --- for_each: element doubling ---
@@ -425,7 +445,9 @@ void test_for_each_capture(tci_test_fixture<TenT> &fix) {
 
   auto result = tci::get_elem(ctx, tensor, {0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(result), 1.5, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(result), 0.5, eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(result), 0.5, eps);
+  }
 }
 
 // --- for_each: const version ---
@@ -445,7 +467,9 @@ template <typename TenT> void test_for_each_const(tci_test_fixture<TenT> &fix) {
                 [&sum](const Elem &elem) { sum = sum + elem; });
 
   TCICT_ASSERT_CLOSE(real_part<TenT>(sum), 6.0, eps);
-  TCICT_ASSERT_CLOSE(imag_part<TenT>(sum), 9.0, eps);
+  if constexpr (is_complex_v<TenT>) {
+    TCICT_ASSERT_CLOSE(imag_part<TenT>(sum), 9.0, eps);
+  }
 }
 
 // --- for_each: element-wise inversion ---
@@ -463,7 +487,7 @@ void test_for_each_inversion(tci_test_fixture<TenT> &fix) {
 
   tci::for_each(ctx, tensor, [](Elem &elem) {
     if (std::abs(elem) > 1e-12) {
-      elem = Elem(1.0, 0.0) / elem;
+      elem = make_elem<TenT>(1.0, 0.0) / elem;
     }
   });
 

--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -194,8 +194,10 @@ void test_real_imag_inplace(tci_test_fixture<TenT> &fix) {
   tci::imag(ctx, tensor, imag_output);
 
   using RealTenT = tci::real_ten_t<TenT>;
-  // Real side: tci::real copies the real parts (== the stored values, since
-  // make_elem drops imag for real TenT; identity for complex TenT).
+  // Real side: tci::real copies the real parts. For real TenT it is a
+  // deep copy (identity), and make_elem already dropped the imaginary
+  // argument so these are the stored values; for complex TenT, tci::real
+  // extracts the real components into real_output.
   TCICT_ASSERT_CLOSE(
       real_part<RealTenT>(tci::get_elem(ctx, real_output, {0, 0})), 5.25, eps);
   TCICT_ASSERT_CLOSE(

--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -154,22 +154,25 @@ void test_imag_extraction(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_IMAG
   return;
 #endif
-  // Per TCI spec, tci::imag on a real tensor yields a zero tensor, so the
-  // non-zero imaginary expectations below are meaningful only for complex TenT.
+  auto &ctx = fix.context();
+  auto eps = fix.epsilon();
+  auto tensor = tci::zeros<TenT>(ctx, {2, 2});
+  tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
+  tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.59, 0.58));
+
+  auto imag_tensor = tci::imag(ctx, tensor);
+
+  using RealTenT = tci::real_ten_t<TenT>;
+  auto elem00 = tci::get_elem(ctx, imag_tensor, {0, 0});
+  auto elem11 = tci::get_elem(ctx, imag_tensor, {1, 1});
   if constexpr (is_complex_v<TenT>) {
-    auto &ctx = fix.context();
-    auto eps = fix.epsilon();
-    auto tensor = tci::zeros<TenT>(ctx, {2, 2});
-    tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(3.14, 2.71));
-    tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-1.59, 0.58));
-
-    auto imag_tensor = tci::imag(ctx, tensor);
-
-    using RealTenT = tci::real_ten_t<TenT>;
-    auto elem00 = tci::get_elem(ctx, imag_tensor, {0, 0});
-    auto elem11 = tci::get_elem(ctx, imag_tensor, {1, 1});
+    // Complex input: imag(tensor) extracts the imaginary parts set above.
     TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 2.71, eps);
     TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), 0.58, eps);
+  } else {
+    // Real input: tci::imag returns a zero tensor per TCI spec.
+    TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 0.0, eps);
+    TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), 0.0, eps);
   }
 }
 
@@ -180,28 +183,35 @@ void test_real_imag_inplace(tci_test_fixture<TenT> &fix) {
 #if defined(TCICT_SKIP_REAL) || defined(TCICT_SKIP_IMAG)
   return;
 #endif
-  // Per TCI spec, tci::imag on a real tensor yields a zero tensor; the
-  // imaginary-side expectations below assume complex input.
+  auto &ctx = fix.context();
+  auto eps = fix.epsilon();
+  auto tensor = tci::zeros<TenT>(ctx, {2, 2});
+  tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(5.25, 7.75));
+  tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-2.25, -3.75));
+
+  tci::real_ten_t<TenT> real_output, imag_output;
+  tci::real(ctx, tensor, real_output);
+  tci::imag(ctx, tensor, imag_output);
+
+  using RealTenT = tci::real_ten_t<TenT>;
+  // Real side: tci::real copies the real parts (== the stored values, since
+  // make_elem drops imag for real TenT; identity for complex TenT).
+  TCICT_ASSERT_CLOSE(
+      real_part<RealTenT>(tci::get_elem(ctx, real_output, {0, 0})), 5.25, eps);
+  TCICT_ASSERT_CLOSE(
+      real_part<RealTenT>(tci::get_elem(ctx, real_output, {1, 1})), -2.25, eps);
   if constexpr (is_complex_v<TenT>) {
-    auto &ctx = fix.context();
-    auto eps = fix.epsilon();
-    auto tensor = tci::zeros<TenT>(ctx, {2, 2});
-    tci::set_elem(ctx, tensor, {0, 0}, make_elem<TenT>(5.25, 7.75));
-    tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(-2.25, -3.75));
-
-    tci::real_ten_t<TenT> real_output, imag_output;
-    tci::real(ctx, tensor, real_output);
-    tci::imag(ctx, tensor, imag_output);
-
-    using RealTenT = tci::real_ten_t<TenT>;
-    TCICT_ASSERT_CLOSE(
-        real_part<RealTenT>(tci::get_elem(ctx, real_output, {0, 0})), 5.25, eps);
-    TCICT_ASSERT_CLOSE(
-        real_part<RealTenT>(tci::get_elem(ctx, real_output, {1, 1})), -2.25, eps);
+    // Complex input: imag_output holds the imaginary parts set above.
     TCICT_ASSERT_CLOSE(
         real_part<RealTenT>(tci::get_elem(ctx, imag_output, {0, 0})), 7.75, eps);
     TCICT_ASSERT_CLOSE(
         real_part<RealTenT>(tci::get_elem(ctx, imag_output, {1, 1})), -3.75, eps);
+  } else {
+    // Real input: tci::imag yields a zero tensor per TCI spec.
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, imag_output, {0, 0})), 0.0, eps);
+    TCICT_ASSERT_CLOSE(
+        real_part<RealTenT>(tci::get_elem(ctx, imag_output, {1, 1})), 0.0, eps);
   }
 }
 


### PR DESCRIPTION
## Summary

- Test template functions for complex-specific operations broke when instantiated with real `elem_t`: `imag_part<TenT>(x)` assertions against non-zero expectations always failed, one `tci::to_cplx`-based test triggered a type mismatch, and one `Elem(x, y)` constructor was ill-formed for real scalars.
- Add `is_complex_v<TenT>` trait to `elem_helper.h` and wrap every previously-unguarded `imag_part<TenT>` assertion in `if constexpr (is_complex_v<TenT>) { ... }`.
- For `test_imag_extraction` and `test_real_imag_inplace`, assertions are branched (real path verifies spec-mandated zero / identity behavior for `tci::imag` and `tci::real`) rather than entirely skipped — so broken real-tensor implementations are still caught.
- `test_to_cplx_complex_to_complex` is fully body-guarded (for real `TenT` the expression `imag_part<TenT>(cplx_elem)` is a compile-time type mismatch against `elem_t<TenT>`).
- `test_cplx_conj_{in,out}ofplace` keep real-side coverage: since `cplx_conj` on real tensors is a spec no-op / deep copy, `real_part` assertions run for both branches and only `imag_part` assertions are gated.
- Replace `Elem(1.0, 0.0) / elem` with `make_elem<TenT>(1.0, 0.0) / elem` in `test_for_each_inversion`.
- Unify the 6 existing `std::is_same_v<tci::elem_t<TenT>, tci::cplx_t<TenT>>` uses to the new `is_complex_v<TenT>`.

Closes #30.

## Test plan

- [x] cytnx downstream rebuilds cleanly with the modified headers.
- [x] No regression on existing complex tests (baseline: 133 pass / 3 fail / 1 skip, 6293/6293 assertions — identical to pre-change baseline; the 3 failures are pre-existing and unrelated: two `/tmp` file I/O fixture issues and one `tci::order` check).
- [ ] Empirical real-type validation arrives with #31, which wires up real-type registration. At that point the spec-mandated real paths (`tci::imag(real) = 0`, `tci::real(real) = identity`, `tci::cplx_conj(real)` = no-op/deep-copy) will be exercised for the first time.

## Notes

- Adding non-zero imaginary inputs to tests that currently use only real values (the "Use non-zero imaginary values ..." bullet in #30) is deferred to follow-up issues — that work requires per-test design decisions beyond the mechanical guard pattern applied here.