### PR TITLE
feat(adapters): add bulk test registration macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For selectively registering specific tests (e.g., during incremental backend dev
 #include <complex>
 
 #define TCICT_DOCTEST_CASE(category, test_func, TenT)          \
-  TEST_CASE("TCICT: " category " - " #test_func) {            \
+  DOCTEST_TEST_CASE("TCICT: " category " - " #test_func) {     \
     tcict::tci_test_fixture<TenT> fix;                         \
     tcict::tests::test_func<TenT>(fix);                        \
   }
@@ -83,7 +83,7 @@ TCICT_DOCTEST_CASE("construction", test_eye, MyTensor)
 
 ### 4. Skip unimplemented functions
 
-Define `TCICT_SKIP_*` macros to opt out of tests for functions a backend has not yet implemented. Each skip macro **excludes the test body at preprocessing time**, so the corresponding `tci::*` function does not even need to be declared:
+Define `TCICT_SKIP_*` macros to opt out of tests for functions a backend has not yet implemented. Each skip macro **excludes — at preprocessing time — the body of the test(s) it directly guards**, removing those references to the corresponding `tci::*` API:
 
 ```cmake
 target_compile_definitions(my_tests PRIVATE
@@ -93,6 +93,8 @@ target_compile_definitions(my_tests PRIVATE
 ```
 
 A skipped test still compiles, registers as a test case, and immediately passes (it has no assertions). See `include/tcict/skip.h` for the full list.
+
+**Caveat: skip is per-test, not per-API.** The same `tci::*` function may be called as a setup / verification helper in unrelated tests. For example, `tci::get_elem` is used inside many tests beyond the one guarded by `TCICT_SKIP_GET_ELEM`. Skipping a single feature therefore does not guarantee that every reference to its API disappears — to compile against a backend that omits a particular declaration, you may need to skip every test that uses it.
 
 **Baseline requirement.** Some functions must always be declared, regardless of skip macros, because they are used as setup / teardown by every test fixture:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ TCICT_DOCTEST_CASE("construction", test_eye, MyTensor)
 
 ### 4. Skip unimplemented functions
 
-Define `TCICT_SKIP_*` macros to opt out of tests for functions not yet implemented:
+Define `TCICT_SKIP_*` macros to opt out of tests for functions a backend has not yet implemented. Each skip macro **excludes the test body at preprocessing time**, so the corresponding `tci::*` function does not even need to be declared:
 
 ```cmake
 target_compile_definitions(my_tests PRIVATE
@@ -92,7 +92,14 @@ target_compile_definitions(my_tests PRIVATE
 )
 ```
 
-See `include/tcict/skip.h` for the full list of available skip macros.
+A skipped test still compiles, registers as a test case, and immediately passes (it has no assertions). See `include/tcict/skip.h` for the full list.
+
+**Baseline requirement.** Some functions must always be declared, regardless of skip macros, because they are used as setup / teardown by every test fixture:
+
+- `tci::create_context`, `tci::destroy_context` (called by `tci_test_fixture`'s constructor/destructor)
+- `tci::tensor_traits<TenT>` and the type aliases it exports
+
+A backend that does not provide these cannot use TCICT at all, with or without skip macros.
 
 ## Test Categories
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Use the provided doctest adapter to register all applicable tests for each type 
 #include <tcict/adapters/doctest.h>
 #include <my_backend/tci.h>
 
+#include <complex>
+
 using MyTen_F  = my_backend::Tensor<float>;
 using MyTen_D  = my_backend::Tensor<double>;
 using MyTen_CF = my_backend::Tensor<std::complex<float>>;
@@ -61,6 +63,8 @@ For selectively registering specific tests (e.g., during incremental backend dev
 #include <tcict/tcict.h>
 #include <my_backend/tci.h>
 #include <doctest/doctest.h>
+
+#include <complex>
 
 #define TCICT_DOCTEST_CASE(category, test_func, TenT)          \
   TEST_CASE("TCICT: " category " - " #test_func) {            \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ TCICT_DOCTEST_REGISTER_CPLX(cdouble, MyTen_CD)
 
 Constraints:
 - `tag` must be identifier-like (stringized into the `TEST_CASE` name to disambiguate type variants).
-- `TenT` must be a single preprocessor token — use a `using` alias. Types with unparenthesized commas (`std::map<K, V>`) cannot be passed directly.
+- `TenT` must be passable as a single macro argument. Types with unparenthesized commas (for example, `std::map<K, V>`) cannot be passed directly, so use a `using` alias in those cases.
 
 #### Option B — Per-test registration (fine-grained control)
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Each backend provides a small bridge file that maps TCICT test functions to the 
 
 Use the provided doctest adapter to register all applicable tests for each type variant with a single macro call:
 
+The backend's TCI header must be included **before** the adapter, because some test templates call non-dependent `tci::` functions (e.g., `tci::create_context` in the fixture constructor) that are resolved at the first parsing phase.
+
 ```cpp
-#include <tcict/adapters/doctest.h>
-#include <my_backend/tci.h>
+#include <my_backend/tci.h>           // backend first: declares tci::create_context, tci::zeros, ...
+#include <tcict/adapters/doctest.h>   // then the adapter, which pulls in the test templates
 
 #include <complex>
 
@@ -60,8 +62,8 @@ Constraints:
 For selectively registering specific tests (e.g., during incremental backend development), use the per-test bridge:
 
 ```cpp
+#include <my_backend/tci.h>           // backend first (see note in Option A)
 #include <tcict/tcict.h>
-#include <my_backend/tci.h>
 #include <doctest/doctest.h>
 
 #include <complex>

--- a/README.md
+++ b/README.md
@@ -23,15 +23,43 @@ git submodule add https://github.com/ultimatile/tensor-computing-interface-confo
 target_include_directories(my_tests PRIVATE ${CMAKE_SOURCE_DIR}/external/tcict/include)
 ```
 
-### 3. Write a thin registration layer
+### 3. Register tests
 
-Each backend provides a small bridge file that maps TCICT test functions to the backend's test framework.
+Each backend provides a small bridge file that maps TCICT test functions to the backend's test framework. Two options are available, depending on the backend's needs.
+
+#### Option A — Bulk registration (recommended)
+
+Use the provided doctest adapter to register all applicable tests for each type variant with a single macro call:
+
+```cpp
+#include <tcict/adapters/doctest.h>
+#include <my_backend/tci.h>
+
+using MyTen_F  = my_backend::Tensor<float>;
+using MyTen_D  = my_backend::Tensor<double>;
+using MyTen_CF = my_backend::Tensor<std::complex<float>>;
+using MyTen_CD = my_backend::Tensor<std::complex<double>>;
+
+TCICT_DOCTEST_REGISTER_REAL(float,   MyTen_F)
+TCICT_DOCTEST_REGISTER_REAL(double,  MyTen_D)
+TCICT_DOCTEST_REGISTER_CPLX(cfloat,  MyTen_CF)
+TCICT_DOCTEST_REGISTER_CPLX(cdouble, MyTen_CD)
+```
+
+`TCICT_DOCTEST_REGISTER_REAL` registers all `ALL_TYPES` tests plus the `REAL_ONLY` tests (currently `test_to_cplx_outofplace`, `test_to_cplx_inplace`).
+`TCICT_DOCTEST_REGISTER_CPLX` registers all `ALL_TYPES` tests plus the `CPLX_ONLY` tests (currently `test_to_cplx_complex_to_complex`).
+
+Constraints:
+- `tag` must be identifier-like (stringized into the `TEST_CASE` name to disambiguate type variants).
+- `TenT` must be a single preprocessor token — use a `using` alias. Types with unparenthesized commas (`std::map<K, V>`) cannot be passed directly.
+
+#### Option B — Per-test registration (fine-grained control)
+
+For selectively registering specific tests (e.g., during incremental backend development), use the per-test bridge:
 
 ```cpp
 #include <tcict/tcict.h>
 #include <my_backend/tci.h>
-
-// Example with doctest
 #include <doctest/doctest.h>
 
 #define TCICT_DOCTEST_CASE(category, test_func, TenT)          \
@@ -77,6 +105,8 @@ See `include/tcict/skip.h` for the full list of available skip macros.
 - **`fixture.h`** -- `tci_test_fixture<TenT>` template managing context lifecycle and epsilon
 - **`elem_helper.h`** -- `make_elem<TenT>(re, im)` and `real_part`/`imag_part` helpers for backend-agnostic element construction
 - **`skip.h`** -- `TCICT_SKIP_*` opt-out macros for unimplemented functions
+- **`tests/_list.h`** -- X-macro aggregators (`TCICT_FOREACH_TEST_ALL_TYPES`, `_REAL_ONLY`, `_CPLX_ONLY`) used by framework adapters
+- **`adapters/doctest.h`** -- Bulk-registration bridge for doctest (`TCICT_DOCTEST_REGISTER_REAL/CPLX`)
 
 ## Requirements
 

--- a/include/tcict/adapters/doctest.h
+++ b/include/tcict/adapters/doctest.h
@@ -30,8 +30,10 @@
 #endif
 
 // Single-case bridge; suitable as the X-callable of TCICT_FOREACH_*.
+// Uses the prefixed DOCTEST_TEST_CASE so this adapter still compiles when
+// users enable DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES.
 #define TCICT_DOCTEST_CASE_BRIDGE(tag, TenT, category, fn) \
-  TEST_CASE("TCICT[" #tag "]: " category " - " #fn) { \
+  DOCTEST_TEST_CASE("TCICT[" #tag "]: " category " - " #fn) { \
     tcict::tci_test_fixture<TenT> fix_; \
     tcict::tests::fn<TenT>(fix_); \
   }

--- a/include/tcict/adapters/doctest.h
+++ b/include/tcict/adapters/doctest.h
@@ -2,8 +2,13 @@
 
 // Doctest adapter for bulk registration of TCICT conformance tests.
 //
+// Include the backend's TCI header BEFORE this adapter: some test templates
+// call non-dependent `tci::` functions (notably tci::create_context in the
+// fixture constructor) that must be visible at the first parsing phase.
+//
 // Usage:
-//   #include <tcict/adapters/doctest.h>
+//   #include <my_backend/tci.h>           // backend first
+//   #include <tcict/adapters/doctest.h>   // then the adapter
 //   using MyTen_F  = backend::Tensor<float>;
 //   using MyTen_CD = backend::Tensor<std::complex<double>>;
 //   TCICT_DOCTEST_REGISTER_REAL(float,   MyTen_F)

--- a/include/tcict/adapters/doctest.h
+++ b/include/tcict/adapters/doctest.h
@@ -11,9 +11,9 @@
 //
 // `tag` is stringized into the TEST_CASE name to disambiguate across type
 // variants; it must be identifier-like.
-// `TenT` must be a single preprocessor token (a typedef/`using` alias).
-// Types with unparenthesized commas (`std::map<K, V>`) cannot be passed
-// directly — alias them first.
+// `TenT` must be passable as a single macro argument. Types with
+// unparenthesized commas (e.g., `std::map<K, V>`) cannot be passed directly;
+// in those cases create a `using` alias first.
 
 #include <tcict/fixture.h>
 #include <tcict/tests/_list.h>

--- a/include/tcict/adapters/doctest.h
+++ b/include/tcict/adapters/doctest.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// Doctest adapter for bulk registration of TCICT conformance tests.
+//
+// Usage:
+//   #include <tcict/adapters/doctest.h>
+//   using MyTen_F  = backend::Tensor<float>;
+//   using MyTen_CD = backend::Tensor<std::complex<double>>;
+//   TCICT_DOCTEST_REGISTER_REAL(float,   MyTen_F)
+//   TCICT_DOCTEST_REGISTER_CPLX(cdouble, MyTen_CD)
+//
+// `tag` is stringized into the TEST_CASE name to disambiguate across type
+// variants; it must be identifier-like.
+// `TenT` must be a single preprocessor token (a typedef/`using` alias).
+// Types with unparenthesized commas (`std::map<K, V>`) cannot be passed
+// directly — alias them first.
+
+#include <tcict/fixture.h>
+#include <tcict/tests/_list.h>
+
+#include <doctest/doctest.h>
+
+// Single-case bridge; suitable as the X-callable of TCICT_FOREACH_*.
+#define TCICT_DOCTEST_CASE_BRIDGE(tag, TenT, category, fn) \
+  TEST_CASE("TCICT[" #tag "]: " category " - " #fn) { \
+    tcict::tci_test_fixture<TenT> fix_; \
+    tcict::tests::fn<TenT>(fix_); \
+  }
+
+// Register ALL_TYPES + REAL_ONLY tests for a real TenT.
+#define TCICT_DOCTEST_REGISTER_REAL(tag, TenT) \
+  TCICT_FOREACH_TEST_ALL_TYPES(TCICT_DOCTEST_CASE_BRIDGE, tag, TenT) \
+  TCICT_FOREACH_TEST_REAL_ONLY(TCICT_DOCTEST_CASE_BRIDGE, tag, TenT)
+
+// Register ALL_TYPES + CPLX_ONLY tests for a complex TenT.
+#define TCICT_DOCTEST_REGISTER_CPLX(tag, TenT) \
+  TCICT_FOREACH_TEST_ALL_TYPES(TCICT_DOCTEST_CASE_BRIDGE, tag, TenT) \
+  TCICT_FOREACH_TEST_CPLX_ONLY(TCICT_DOCTEST_CASE_BRIDGE, tag, TenT)

--- a/include/tcict/adapters/doctest.h
+++ b/include/tcict/adapters/doctest.h
@@ -20,6 +20,15 @@
 
 #include <doctest/doctest.h>
 
+// doctest derives anonymous TEST_CASE registration symbols from __COUNTER__
+// when available, and falls back to __LINE__ otherwise. Because the bulk
+// macros below expand many TEST_CASE invocations from a single source line,
+// the __LINE__ fallback would collide. Fail loudly here instead of producing
+// confusing duplicate-symbol errors at link time.
+#if !defined(__COUNTER__)
+#error "TCICT bulk registration (TCICT_DOCTEST_REGISTER_*) requires __COUNTER__ support; use the per-test TCICT_DOCTEST_CASE pattern on this compiler."
+#endif
+
 // Single-case bridge; suitable as the X-callable of TCICT_FOREACH_*.
 #define TCICT_DOCTEST_CASE_BRIDGE(tag, TenT, category, fn) \
   TEST_CASE("TCICT[" #tag "]: " category " - " #fn) { \

--- a/include/tcict/tests/_list.h
+++ b/include/tcict/tests/_list.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Aggregates the per-header TCICT_FOREACH_*_TEST macros into suite-wide
+// iterators used by framework adapters (see include/tcict/adapters/*.h).
+//
+// Contract: each TCICT_FOREACH_*(X, ...) expands X once per test as
+//   X(__VA_ARGS__, category_str, test_fn_name)
+// Callers must supply at least one forwarded argument (C++17 has no portable
+// __VA_OPT__). The documented adapters pass (tag, TenT), satisfying this.
+
+#include <tcict/tests/construction.h>
+#include <tcict/tests/io_operations.h>
+#include <tcict/tests/linear_algebra.h>
+#include <tcict/tests/miscellaneous.h>
+#include <tcict/tests/read_only_getters.h>
+#include <tcict/tests/tensor_manipulation.h>
+
+// All tests that are safe for both real and complex TenT.
+#define TCICT_FOREACH_TEST_ALL_TYPES(X, ...) \
+  TCICT_FOREACH_CONSTRUCTION_TEST_ALL_TYPES(X, __VA_ARGS__) \
+  TCICT_FOREACH_IO_OPERATIONS_TEST_ALL_TYPES(X, __VA_ARGS__) \
+  TCICT_FOREACH_LINEAR_ALGEBRA_TEST_ALL_TYPES(X, __VA_ARGS__) \
+  TCICT_FOREACH_MISCELLANEOUS_TEST_ALL_TYPES(X, __VA_ARGS__) \
+  TCICT_FOREACH_READ_ONLY_GETTERS_TEST_ALL_TYPES(X, __VA_ARGS__) \
+  TCICT_FOREACH_TENSOR_MANIPULATION_TEST_ALL_TYPES(X, __VA_ARGS__)
+
+// Tests meaningful only for real TenT (e.g., tci::to_cplx input must be real).
+#define TCICT_FOREACH_TEST_REAL_ONLY(X, ...) \
+  TCICT_FOREACH_TENSOR_MANIPULATION_TEST_REAL_ONLY(X, __VA_ARGS__)
+
+// Tests whose body is guarded `if constexpr (is_complex_v<TenT>)`; registering
+// for real TenT would produce redundant no-op test cases.
+#define TCICT_FOREACH_TEST_CPLX_ONLY(X, ...) \
+  TCICT_FOREACH_TENSOR_MANIPULATION_TEST_CPLX_ONLY(X, __VA_ARGS__)

--- a/include/tcict/tests/construction.h
+++ b/include/tcict/tests/construction.h
@@ -15,9 +15,7 @@ namespace tcict { namespace tests {
 
 template <typename TenT>
 void test_zeros(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ZEROS
-  return;
-#endif
+#ifndef TCICT_SKIP_ZEROS
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {2, 3};
@@ -39,15 +37,16 @@ void test_zeros(tci_test_fixture<TenT>& fix) {
       }
     }
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- fill ---
 
 template <typename TenT>
 void test_fill(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_FILL
-  return;
-#endif
+#ifndef TCICT_SKIP_FILL
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto val = make_elem<TenT>(42.0, -7.5);
@@ -68,15 +67,16 @@ void test_fill(tci_test_fixture<TenT>& fix) {
       }
     }
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- eye ---
 
 template <typename TenT>
 void test_eye(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_EYE
-  return;
-#endif
+#ifndef TCICT_SKIP_EYE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   TenT identity;
@@ -101,15 +101,16 @@ void test_eye(tci_test_fixture<TenT>& fix) {
       }
     }
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- random (shape {2,3}, verifies all elements) ---
 
 template <typename TenT>
 void test_random_inplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_RANDOM
-  return;
-#endif
+#ifndef TCICT_SKIP_RANDOM
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {2, 3};
@@ -139,15 +140,16 @@ void test_random_inplace(tci_test_fixture<TenT>& fix) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_01), 1.5, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_12), 5.5, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- random (out-of-place) ---
 
 template <typename TenT>
 void test_random_outofplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_RANDOM
-  return;
-#endif
+#ifndef TCICT_SKIP_RANDOM
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {2, 2};
@@ -168,15 +170,16 @@ void test_random_outofplace(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem_11), 3.5, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- copy (in-place) ---
 
 template <typename TenT>
 void test_copy_inplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_COPY
-  return;
-#endif
+#ifndef TCICT_SKIP_COPY
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 3});
@@ -199,15 +202,16 @@ void test_copy_inplace(tci_test_fixture<TenT>& fix) {
 
   TCICT_ASSERT(tci::shape(ctx, a) == tci::shape(ctx, b));
   TCICT_ASSERT(tci::order(ctx, a) == tci::order(ctx, b));
+#else
+  (void)fix;
+#endif
 }
 
 // --- copy (out-of-place) ---
 
 template <typename TenT>
 void test_copy_outofplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_COPY
-  return;
-#endif
+#ifndef TCICT_SKIP_COPY
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {3, 4, 2});
@@ -225,15 +229,16 @@ void test_copy_outofplace(tci_test_fixture<TenT>& fix) {
 
   TCICT_ASSERT(tci::shape(ctx, a) == tci::shape(ctx, b));
   TCICT_ASSERT(tci::order(ctx, a) == tci::order(ctx, b));
+#else
+  (void)fix;
+#endif
 }
 
 // --- copy independence ---
 
 template <typename TenT>
 void test_copy_independence(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_COPY
-  return;
-#endif
+#ifndef TCICT_SKIP_COPY
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 2});
@@ -247,15 +252,16 @@ void test_copy_independence(tci_test_fixture<TenT>& fix) {
 
   auto orig_val = tci::get_elem(ctx, a, {0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(orig_val), 999.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- copy single element ---
 
 template <typename TenT>
 void test_copy_single_element(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_COPY
-  return;
-#endif
+#ifndef TCICT_SKIP_COPY
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {1});
@@ -268,15 +274,16 @@ void test_copy_single_element(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(val), 2.71, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- copy large tensor ---
 
 template <typename TenT>
 void test_copy_large(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_COPY
-  return;
-#endif
+#ifndef TCICT_SKIP_COPY
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {10, 10, 10});
@@ -299,15 +306,16 @@ void test_copy_large(tci_test_fixture<TenT>& fix) {
   }
 
   TCICT_ASSERT(tci::shape(ctx, a) == tci::shape(ctx, b));
+#else
+  (void)fix;
+#endif
 }
 
 // --- assign_from_range (row-major) ---
 
 template <typename TenT>
 void test_assign_from_range_row_major(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ASSIGN_FROM_RANGE
-  return;
-#endif
+#ifndef TCICT_SKIP_ASSIGN_FROM_RANGE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -335,15 +343,16 @@ void test_assign_from_range_row_major(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 1})), 2.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 0})), 4.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 2})), 6.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- assign_from_range (column-major) ---
 
 template <typename TenT>
 void test_assign_from_range_column_major(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ASSIGN_FROM_RANGE
-  return;
-#endif
+#ifndef TCICT_SKIP_ASSIGN_FROM_RANGE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -366,15 +375,16 @@ void test_assign_from_range_column_major(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 1})), 2.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 0})), 3.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 4.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- allocate ---
 
 template <typename TenT>
 void test_allocate_3d(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ALLOCATE
-  return;
-#endif
+#ifndef TCICT_SKIP_ALLOCATE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {3, 4, 5};
@@ -396,13 +406,14 @@ void test_allocate_3d(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 template <typename TenT>
 void test_allocate_2d(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ALLOCATE
-  return;
-#endif
+#ifndef TCICT_SKIP_ALLOCATE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {2, 3};
@@ -423,13 +434,14 @@ void test_allocate_2d(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 template <typename TenT>
 void test_allocate_1d(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ALLOCATE
-  return;
-#endif
+#ifndef TCICT_SKIP_ALLOCATE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   tci::shape_t<TenT> shape = {10};
@@ -449,54 +461,58 @@ void test_allocate_1d(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(got), imag_part<TenT>(val), eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- clear ---
 
 template <typename TenT>
 void test_clear_basic(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_CLEAR
-  return;
-#endif
+#ifndef TCICT_SKIP_CLEAR
   auto& ctx = fix.context();
   auto tensor = tci::eye<TenT>(ctx, 3);
   TCICT_ASSERT(tci::size(ctx, tensor) == 9);
   TCICT_ASSERT_NOTHROW(tci::clear(ctx, tensor));
   TCICT_ASSERT(tci::order(ctx, tensor) == 0);
   TCICT_ASSERT(tci::shape(ctx, tensor).empty());
+#else
+  (void)fix;
+#endif
 }
 
 template <typename TenT>
 void test_clear_empty(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_CLEAR
-  return;
-#endif
+#ifndef TCICT_SKIP_CLEAR
   auto& ctx = fix.context();
   TenT empty_tensor;
   TCICT_ASSERT_NOTHROW(tci::clear(ctx, empty_tensor));
   TCICT_ASSERT(tci::order(ctx, empty_tensor) == 0);
+#else
+  (void)fix;
+#endif
 }
 
 template <typename TenT>
 void test_clear_and_reallocate(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_CLEAR
-  return;
-#endif
+#ifndef TCICT_SKIP_CLEAR
   auto& ctx = fix.context();
   auto tensor = tci::eye<TenT>(ctx, 2);
   tci::clear(ctx, tensor);
   TCICT_ASSERT(tci::order(ctx, tensor) == 0);
   TCICT_ASSERT_NOTHROW(tensor = tci::allocate<TenT>(ctx, {2, 2}));
   TCICT_ASSERT(tci::order(ctx, tensor) == 2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- move (in-place) ---
 
 template <typename TenT>
 void test_move_inplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_MOVE
-  return;
-#endif
+#ifndef TCICT_SKIP_MOVE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto source = tci::eye<TenT>(ctx, 3);
@@ -517,15 +533,16 @@ void test_move_inplace(tci_test_fixture<TenT>& fix) {
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);
+#else
+  (void)fix;
+#endif
 }
 
 // --- move (out-of-place) ---
 
 template <typename TenT>
 void test_move_outofplace(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_MOVE
-  return;
-#endif
+#ifndef TCICT_SKIP_MOVE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto source = tci::eye<TenT>(ctx, 2);
@@ -546,28 +563,30 @@ void test_move_outofplace(tci_test_fixture<TenT>& fix) {
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);
+#else
+  (void)fix;
+#endif
 }
 
 // --- move empty tensor ---
 
 template <typename TenT>
 void test_move_empty(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_MOVE
-  return;
-#endif
+#ifndef TCICT_SKIP_MOVE
   auto& ctx = fix.context();
   TenT empty_source, empty_result;
   TCICT_ASSERT_NOTHROW(empty_result = tci::move(ctx, empty_source));
   TCICT_ASSERT(tci::order(ctx, empty_source) == 0);
+#else
+  (void)fix;
+#endif
 }
 
 // --- move preserves values ---
 
 template <typename TenT>
 void test_move_preserves_values(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_MOVE
-  return;
-#endif
+#ifndef TCICT_SKIP_MOVE
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto source = tci::zeros<TenT>(ctx, {2, 3});
@@ -591,6 +610,9 @@ void test_move_preserves_values(tci_test_fixture<TenT>& fix) {
 
   // Verify source is invalidated after move
   TCICT_ASSERT(tci::order(ctx, source) == 0);
+#else
+  (void)fix;
+#endif
 }
 
 }}  // namespace tcict::tests

--- a/include/tcict/tests/construction.h
+++ b/include/tcict/tests/construction.h
@@ -594,3 +594,29 @@ void test_move_preserves_values(tci_test_fixture<TenT>& fix) {
 }
 
 }}  // namespace tcict::tests
+
+// Bulk registration helper: invokes X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+#define TCICT_FOREACH_CONSTRUCTION_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "construction", test_zeros) \
+  X(__VA_ARGS__, "construction", test_fill) \
+  X(__VA_ARGS__, "construction", test_eye) \
+  X(__VA_ARGS__, "construction", test_random_inplace) \
+  X(__VA_ARGS__, "construction", test_random_outofplace) \
+  X(__VA_ARGS__, "construction", test_copy_inplace) \
+  X(__VA_ARGS__, "construction", test_copy_outofplace) \
+  X(__VA_ARGS__, "construction", test_copy_independence) \
+  X(__VA_ARGS__, "construction", test_copy_single_element) \
+  X(__VA_ARGS__, "construction", test_copy_large) \
+  X(__VA_ARGS__, "construction", test_assign_from_range_row_major) \
+  X(__VA_ARGS__, "construction", test_assign_from_range_column_major) \
+  X(__VA_ARGS__, "construction", test_allocate_3d) \
+  X(__VA_ARGS__, "construction", test_allocate_2d) \
+  X(__VA_ARGS__, "construction", test_allocate_1d) \
+  X(__VA_ARGS__, "construction", test_clear_basic) \
+  X(__VA_ARGS__, "construction", test_clear_empty) \
+  X(__VA_ARGS__, "construction", test_clear_and_reallocate) \
+  X(__VA_ARGS__, "construction", test_move_inplace) \
+  X(__VA_ARGS__, "construction", test_move_outofplace) \
+  X(__VA_ARGS__, "construction", test_move_empty) \
+  X(__VA_ARGS__, "construction", test_move_preserves_values)

--- a/include/tcict/tests/io_operations.h
+++ b/include/tcict/tests/io_operations.h
@@ -14,9 +14,7 @@ namespace tcict { namespace tests {
 
 template <typename TenT>
 void test_save_load_roundtrip(tci_test_fixture<TenT>& fix) {
-#if defined(TCICT_SKIP_SAVE) || defined(TCICT_SKIP_LOAD)
-  return;
-#endif
+#if !defined(TCICT_SKIP_SAVE) && !defined(TCICT_SKIP_LOAD)
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -41,15 +39,16 @@ void test_save_load_roundtrip(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(val11), 1.0, eps);
 
   std::remove(filepath.c_str());
+#else
+  (void)fix;
+#endif
 }
 
 // --- load verifies data integrity against original ---
 
 template <typename TenT>
 void test_load_data_integrity(tci_test_fixture<TenT>& fix) {
-#if defined(TCICT_SKIP_SAVE) || defined(TCICT_SKIP_LOAD)
-  return;
-#endif
+#if !defined(TCICT_SKIP_SAVE) && !defined(TCICT_SKIP_LOAD)
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -65,6 +64,9 @@ void test_load_data_integrity(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT(tci::close(ctx, original, loaded, eps));
 
   std::remove(filepath.c_str());
+#else
+  (void)fix;
+#endif
 }
 
 }}  // namespace tcict::tests

--- a/include/tcict/tests/io_operations.h
+++ b/include/tcict/tests/io_operations.h
@@ -68,3 +68,9 @@ void test_load_data_integrity(tci_test_fixture<TenT>& fix) {
 }
 
 }}  // namespace tcict::tests
+
+// Bulk registration helper: invokes X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+#define TCICT_FOREACH_IO_OPERATIONS_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "io_operations", test_save_load_roundtrip) \
+  X(__VA_ARGS__, "io_operations", test_load_data_integrity)

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -984,3 +984,43 @@ void test_eigvalsh_errors(tci_test_fixture<TenT> &fix) {
 
 } // namespace tests
 } // namespace tcict
+
+// Bulk registration helper: invokes X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+#define TCICT_FOREACH_LINEAR_ALGEBRA_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "linear_algebra", test_norm_identity) \
+  X(__VA_ARGS__, "linear_algebra", test_linear_combine_uniform) \
+  X(__VA_ARGS__, "linear_algebra", test_linear_combine_weighted) \
+  X(__VA_ARGS__, "linear_algebra", test_linear_combine_single) \
+  X(__VA_ARGS__, "linear_algebra", test_normalize_inplace) \
+  X(__VA_ARGS__, "linear_algebra", test_normalize_outofplace) \
+  X(__VA_ARGS__, "linear_algebra", test_normalize_edge_cases) \
+  X(__VA_ARGS__, "linear_algebra", test_norm_2x2) \
+  X(__VA_ARGS__, "linear_algebra", test_contract_matmul) \
+  X(__VA_ARGS__, "linear_algebra", test_contract_dot_product) \
+  X(__VA_ARGS__, "linear_algebra", test_contract_outer_product) \
+  X(__VA_ARGS__, "linear_algebra", test_qr) \
+  X(__VA_ARGS__, "linear_algebra", test_lq) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_value) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_no_truncation) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_bounded) \
+  X(__VA_ARGS__, "linear_algebra", test_eig_identity) \
+  X(__VA_ARGS__, "linear_algebra", test_eigh_identity) \
+  X(__VA_ARGS__, "linear_algebra", test_exp_identity) \
+  X(__VA_ARGS__, "linear_algebra", test_exp_diagonal) \
+  X(__VA_ARGS__, "linear_algebra", test_exp_zero) \
+  X(__VA_ARGS__, "linear_algebra", test_exp_anti_hermitian) \
+  X(__VA_ARGS__, "linear_algebra", test_exp_errors) \
+  X(__VA_ARGS__, "linear_algebra", test_inverse) \
+  X(__VA_ARGS__, "linear_algebra", test_inverse_errors) \
+  X(__VA_ARGS__, "linear_algebra", test_scale_inplace) \
+  X(__VA_ARGS__, "linear_algebra", test_scale_outofplace) \
+  X(__VA_ARGS__, "linear_algebra", test_scale_by_zero) \
+  X(__VA_ARGS__, "linear_algebra", test_trace_partial) \
+  X(__VA_ARGS__, "linear_algebra", test_svd_basic) \
+  X(__VA_ARGS__, "linear_algebra", test_svd_reconstruction) \
+  X(__VA_ARGS__, "linear_algebra", test_eigvals_diagonal) \
+  X(__VA_ARGS__, "linear_algebra", test_eigvals_errors) \
+  X(__VA_ARGS__, "linear_algebra", test_eigvalsh_diagonal) \
+  X(__VA_ARGS__, "linear_algebra", test_eigvalsh_errors)

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -15,9 +15,7 @@ namespace tests {
 // --- norm (basic: identity matrix) ---
 
 template <typename TenT> void test_norm_identity(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_NORM
-  return;
-#endif
+#ifndef TCICT_SKIP_NORM
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto identity = tci::eye<TenT>(ctx, 3);
@@ -25,15 +23,16 @@ template <typename TenT> void test_norm_identity(tci_test_fixture<TenT> &fix) {
   auto norm_val = tci::norm(ctx, identity);
   // Frobenius norm of 3x3 identity = sqrt(3)
   TCICT_ASSERT_CLOSE(norm_val, std::sqrt(3.0), eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- linear_combine: uniform coefficients ---
 
 template <typename TenT>
 void test_linear_combine_uniform(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_LINEAR_COMBINE
-  return;
-#endif
+#ifndef TCICT_SKIP_LINEAR_COMBINE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -68,15 +67,16 @@ void test_linear_combine_uniform(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), 13.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- linear_combine: weighted coefficients ---
 
 template <typename TenT>
 void test_linear_combine_weighted(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_LINEAR_COMBINE
-  return;
-#endif
+#ifndef TCICT_SKIP_LINEAR_COMBINE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -110,15 +110,16 @@ void test_linear_combine_weighted(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), 18.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- linear_combine: single tensor ---
 
 template <typename TenT>
 void test_linear_combine_single(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_LINEAR_COMBINE
-  return;
-#endif
+#ifndef TCICT_SKIP_LINEAR_COMBINE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -136,15 +137,16 @@ void test_linear_combine_single(tci_test_fixture<TenT> &fix) {
                            tci::linear_combine(ctx, single_list, single_coef));
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 0})), 15.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- normalize: in-place ---
 
 template <typename TenT>
 void test_normalize_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_NORMALIZE
-  return;
-#endif
+#ifndef TCICT_SKIP_NORMALIZE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -165,15 +167,16 @@ void test_normalize_inplace(tci_test_fixture<TenT> &fix) {
   // New norm should be 1
   auto new_norm = tci::norm(ctx, tensor);
   TCICT_ASSERT_CLOSE(new_norm, 1.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- normalize: out-of-place ---
 
 template <typename TenT>
 void test_normalize_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_NORMALIZE
-  return;
-#endif
+#ifndef TCICT_SKIP_NORMALIZE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -199,15 +202,16 @@ void test_normalize_outofplace(tci_test_fixture<TenT> &fix) {
 
   auto new_norm = tci::norm(ctx, normalized);
   TCICT_ASSERT_CLOSE(new_norm, 1.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- normalize: edge cases ---
 
 template <typename TenT>
 void test_normalize_edge_cases(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_NORMALIZE
-  return;
-#endif
+#ifndef TCICT_SKIP_NORMALIZE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -224,28 +228,30 @@ void test_normalize_edge_cases(tci_test_fixture<TenT> &fix) {
   auto zero_tensor = tci::zeros<TenT>(ctx, {2, 2});
   auto norm_zero = tci::normalize(ctx, zero_tensor);
   TCICT_ASSERT_CLOSE(std::abs(norm_zero), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- norm: 2x2 identity ---
 
 template <typename TenT> void test_norm_2x2(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_NORM
-  return;
-#endif
+#ifndef TCICT_SKIP_NORM
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto identity = tci::eye<TenT>(ctx, 2);
   auto norm_val = tci::norm(ctx, identity);
   TCICT_ASSERT_CLOSE(norm_val, std::sqrt(2.0), eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- contract: matrix multiplication via Einstein notation ---
 
 template <typename TenT>
 void test_contract_matmul(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONTRACT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONTRACT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 2});
@@ -269,15 +275,16 @@ void test_contract_matmul(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {0, 1})), 22.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {1, 0})), 43.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {1, 1})), 50.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- contract: dot product ---
 
 template <typename TenT>
 void test_contract_dot_product(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONTRACT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONTRACT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {3});
@@ -299,15 +306,16 @@ void test_contract_dot_product(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(c_shape.size() == 1);
   TCICT_ASSERT(c_shape[0] == 1);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {0})), 32.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- contract: outer product ---
 
 template <typename TenT>
 void test_contract_outer_product(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONTRACT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONTRACT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2});
@@ -327,14 +335,15 @@ void test_contract_outer_product(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(c_shape[1] == 3);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {0, 0})), 3.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, c, {1, 2})), 10.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- QR decomposition ---
 
 template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_QR
-  return;
-#endif
+#ifndef TCICT_SKIP_QR
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
@@ -365,14 +374,15 @@ template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
   auto bond_dim = tci::shape(ctx, q)[1];
   auto identity = tci::eye<TenT>(ctx, bond_dim);
   TCICT_ASSERT(tci::close(ctx, qtq, identity, eps * 100));
+#else
+  (void)fix;
+#endif
 }
 
 // --- LQ decomposition ---
 
 template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_LQ
-  return;
-#endif
+#ifndef TCICT_SKIP_LQ
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
@@ -403,11 +413,17 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
   auto bond_dim = tci::shape(ctx, q)[0];
   auto identity = tci::eye<TenT>(ctx, bond_dim);
   TCICT_ASSERT(tci::close(ctx, qqt, identity, eps * 100));
+#else
+  (void)fix;
+#endif
 }
 
 // --- truncated SVD ---
 
+#ifndef TCICT_SKIP_TRUNC_SVD
 // Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1].
+// Only defined when TRUNC_SVD tests are active so partial backends without
+// tci::zeros / tci::set_elem do not need to declare them.
 template <typename TenT>
 TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx) {
   auto matrix = tci::zeros<TenT>(ctx, {4, 4});
@@ -417,11 +433,10 @@ TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &
   tci::set_elem(ctx, matrix, {3, 3}, make_elem<TenT>(0.1));
   return matrix;
 }
+#endif
 
 template <typename TenT> void test_trunc_svd(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRUNC_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_TRUNC_SVD
   auto &ctx = fix.context();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
 
@@ -437,6 +452,9 @@ template <typename TenT> void test_trunc_svd(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(s_shape.size() == 1);
   TCICT_ASSERT(s_shape[0] <= 2);
   TCICT_ASSERT(trunc_err >= 0.0);
+#else
+  (void)fix;
+#endif
 }
 
 /// Verify trunc_err equals the spec formula when truncation occurs.
@@ -445,9 +463,7 @@ template <typename TenT> void test_trunc_svd(tci_test_fixture<TenT> &fix) {
 ///         = 1.01 / 14.01 ≈ 0.07209
 template <typename TenT>
 void test_trunc_svd_trunc_err_value(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRUNC_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_TRUNC_SVD
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -463,14 +479,15 @@ void test_trunc_svd_trunc_err_value(tci_test_fixture<TenT> &fix) {
   tci::real_t<TenT> expected =
       (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
   TCICT_ASSERT_CLOSE(trunc_err, expected, eps);
+#else
+  (void)fix;
+#endif
 }
 
 /// Verify trunc_err == 0 when no truncation occurs (chi_max >= kappa).
 template <typename TenT>
 void test_trunc_svd_trunc_err_no_truncation(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRUNC_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_TRUNC_SVD
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -487,14 +504,15 @@ void test_trunc_svd_trunc_err_no_truncation(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(s_shape.size() == 1);
   TCICT_ASSERT(s_shape[0] == 4);
   TCICT_ASSERT_CLOSE(trunc_err, 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 /// Verify trunc_err is in [0, 1] (relative error is bounded).
 template <typename TenT>
 void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRUNC_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_TRUNC_SVD
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -514,14 +532,15 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
   tci::real_t<TenT> expected =
       (2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
   TCICT_ASSERT_CLOSE(trunc_err, expected, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- eig (general eigendecomposition of identity) ---
 
 template <typename TenT> void test_eig_identity(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIG
-  return;
-#endif
+#ifndef TCICT_SKIP_EIG
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::eye<TenT>(ctx, 2);
@@ -538,14 +557,15 @@ template <typename TenT> void test_eig_identity(tci_test_fixture<TenT> &fix) {
                      1.0, eps);
 
   TCICT_ASSERT(tci::order(ctx, eigenvecs) == 2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- eigh (Hermitian eigendecomposition of identity) ---
 
 template <typename TenT> void test_eigh_identity(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIGH
-  return;
-#endif
+#ifndef TCICT_SKIP_EIGH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::eye<TenT>(ctx, 2);
@@ -563,14 +583,15 @@ template <typename TenT> void test_eigh_identity(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(real_part<RealTenT>(tci::get_elem(ctx, eigenvals, {1})),
                      1.0, eps);
   TCICT_ASSERT(tci::order(ctx, eigenvecs) == 2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- exp: identity matrix ---
 
 template <typename TenT> void test_exp_identity(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXP
-  return;
-#endif
+#ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto identity = tci::eye<TenT>(ctx, 3);
@@ -583,14 +604,15 @@ template <typename TenT> void test_exp_identity(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})),
                      expected_e, eps);
   TCICT_ASSERT_CLOSE(std::abs(tci::get_elem(ctx, result, {0, 1})), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- exp: diagonal matrix ---
 
 template <typename TenT> void test_exp_diagonal(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXP
-  return;
-#endif
+#ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto diagonal = tci::zeros<TenT>(ctx, {2, 2});
@@ -606,14 +628,15 @@ template <typename TenT> void test_exp_diagonal(tci_test_fixture<TenT> &fix) {
                      std::exp(2.0), eps);
   TCICT_ASSERT_CLOSE(std::abs(tci::get_elem(ctx, result, {0, 1})), 0.0, eps);
   TCICT_ASSERT_CLOSE(std::abs(tci::get_elem(ctx, result, {1, 0})), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- exp: zero matrix → identity ---
 
 template <typename TenT> void test_exp_zero(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXP
-  return;
-#endif
+#ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto zero_matrix = tci::zeros<TenT>(ctx, {2, 2});
@@ -626,15 +649,16 @@ template <typename TenT> void test_exp_zero(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), 1.0,
                      eps);
   TCICT_ASSERT_CLOSE(std::abs(tci::get_elem(ctx, result, {0, 1})), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- exp: anti-Hermitian → unitary ---
 
 template <typename TenT>
 void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXP
-  return;
-#endif
+#ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto anti_herm = tci::zeros<TenT>(ctx, {2, 2});
@@ -655,14 +679,15 @@ void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
                      eps * 100);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), c,
                      eps * 100);
+#else
+  (void)fix;
+#endif
 }
 
 // --- exp: error conditions ---
 
 template <typename TenT> void test_exp_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXP
-  return;
-#endif
+#ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
   TenT result;
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
@@ -671,14 +696,15 @@ template <typename TenT> void test_exp_errors(tci_test_fixture<TenT> &fix) {
 
   auto square = tci::zeros<TenT>(ctx, {2, 2});
   TCICT_ASSERT_THROWS(std::invalid_argument, tci::exp(ctx, square, 3, result));
+#else
+  (void)fix;
+#endif
 }
 
 // --- inverse ---
 
 template <typename TenT> void test_inverse(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_INVERSE
-  return;
-#endif
+#ifndef TCICT_SKIP_INVERSE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {2, 2});
@@ -699,27 +725,29 @@ template <typename TenT> void test_inverse(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, inv, {1, 1})), 0.4,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- inverse: non-square error ---
 
 template <typename TenT> void test_inverse_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_INVERSE
-  return;
-#endif
+#ifndef TCICT_SKIP_INVERSE
   auto &ctx = fix.context();
   TenT result;
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
   TCICT_ASSERT_THROWS(std::invalid_argument,
                       tci::inverse(ctx, non_square, 1, result));
+#else
+  (void)fix;
+#endif
 }
 
 // --- scale: in-place ---
 
 template <typename TenT> void test_scale_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SCALE
-  return;
-#endif
+#ifndef TCICT_SKIP_SCALE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -739,15 +767,16 @@ template <typename TenT> void test_scale_inplace(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 4.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- scale: out-of-place ---
 
 template <typename TenT>
 void test_scale_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SCALE
-  return;
-#endif
+#ifndef TCICT_SKIP_SCALE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -765,14 +794,15 @@ void test_scale_outofplace(tci_test_fixture<TenT> &fix) {
   // Original unchanged
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 0})), 3.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- scale: by zero ---
 
 template <typename TenT> void test_scale_by_zero(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SCALE
-  return;
-#endif
+#ifndef TCICT_SKIP_SCALE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -783,14 +813,15 @@ template <typename TenT> void test_scale_by_zero(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 0.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- trace: 2x2 matrix ---
 
 template <typename TenT> void test_trace_partial(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRACE
-  return;
-#endif
+#ifndef TCICT_SKIP_TRACE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -805,14 +836,15 @@ template <typename TenT> void test_trace_partial(tci_test_fixture<TenT> &fix) {
   // TCI spec: all bonds paired yields a scalar (order 0)
   TCICT_ASSERT(tci::order(ctx, result) == 0);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {})), 5.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- svd: basic singular values and shapes ---
 
 template <typename TenT> void test_svd_basic(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_SVD
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -844,15 +876,16 @@ template <typename TenT> void test_svd_basic(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(u_shape[0] == 2);
   TCICT_ASSERT(v_shape.size() == 2);
   TCICT_ASSERT(v_shape[1] == 2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- svd: reconstruction U * diag(S) * V† ≈ A ---
 
 template <typename TenT>
 void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SVD
-  return;
-#endif
+#ifndef TCICT_SKIP_SVD
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -887,15 +920,16 @@ void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
   tci::contract(ctx, u_scaled, "ik", v_dag, "kj", reconstructed, "ij");
 
   TCICT_ASSERT(tci::close(ctx, reconstructed, matrix, eps * 100));
+#else
+  (void)fix;
+#endif
 }
 
 // --- eigvals: diagonal matrix ---
 
 template <typename TenT>
 void test_eigvals_diagonal(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIGVALS
-  return;
-#endif
+#ifndef TCICT_SKIP_EIGVALS
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -923,28 +957,30 @@ void test_eigvals_diagonal(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(ev_real[0], 1.0, eps);
   TCICT_ASSERT_CLOSE(ev_real[1], 2.0, eps);
   TCICT_ASSERT_CLOSE(ev_real[2], 3.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- eigvals: error on non-square ---
 
 template <typename TenT> void test_eigvals_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIGVALS
-  return;
-#endif
+#ifndef TCICT_SKIP_EIGVALS
   auto &ctx = fix.context();
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
   tci::cplx_ten_t<TenT> w;
   TCICT_ASSERT_THROWS(std::invalid_argument,
                       tci::eigvals(ctx, non_square, 1, w));
+#else
+  (void)fix;
+#endif
 }
 
 // --- eigvalsh: symmetric matrix ---
 
 template <typename TenT>
 void test_eigvalsh_diagonal(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIGVALSH
-  return;
-#endif
+#ifndef TCICT_SKIP_EIGVALSH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -966,20 +1002,24 @@ void test_eigvalsh_diagonal(tci_test_fixture<TenT> &fix) {
                      2.0, eps);
   TCICT_ASSERT_CLOSE(real_part<RealTenT>(tci::get_elem(ctx, eigenvalues, {2})),
                      3.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- eigvalsh: error on non-square ---
 
 template <typename TenT>
 void test_eigvalsh_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EIGVALSH
-  return;
-#endif
+#ifndef TCICT_SKIP_EIGVALSH
   auto &ctx = fix.context();
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
   tci::real_ten_t<TenT> w;
   TCICT_ASSERT_THROWS(std::invalid_argument,
                       tci::eigvalsh(ctx, non_square, 1, w));
+#else
+  (void)fix;
+#endif
 }
 
 } // namespace tests

--- a/include/tcict/tests/miscellaneous.h
+++ b/include/tcict/tests/miscellaneous.h
@@ -180,3 +180,15 @@ template <typename TenT> void test_version(tci_test_fixture<TenT> &fix) {
 
 } // namespace tests
 } // namespace tcict
+
+// Bulk registration helper: invokes X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+#define TCICT_FOREACH_MISCELLANEOUS_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "miscellaneous", test_close_identical) \
+  X(__VA_ARGS__, "miscellaneous", test_close_different) \
+  X(__VA_ARGS__, "miscellaneous", test_to_range) \
+  X(__VA_ARGS__, "miscellaneous", test_show) \
+  X(__VA_ARGS__, "miscellaneous", test_convert_same_context) \
+  X(__VA_ARGS__, "miscellaneous", test_convert_different_context) \
+  X(__VA_ARGS__, "miscellaneous", test_convert_data_integrity) \
+  X(__VA_ARGS__, "miscellaneous", test_version)

--- a/include/tcict/tests/miscellaneous.h
+++ b/include/tcict/tests/miscellaneous.h
@@ -17,9 +17,7 @@ namespace tests {
 
 template <typename TenT>
 void test_close_identical(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CLOSE
-  return;
-#endif
+#ifndef TCICT_SKIP_CLOSE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor1 = tci::eye<TenT>(ctx, 2);
@@ -27,15 +25,16 @@ void test_close_identical(tci_test_fixture<TenT> &fix) {
 
   bool are_equal = tci::close(ctx, tensor1, tensor2, eps);
   TCICT_ASSERT(are_equal == true);
+#else
+  (void)fix;
+#endif
 }
 
 // --- close (eq) : different tensors ---
 
 template <typename TenT>
 void test_close_different(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CLOSE
-  return;
-#endif
+#ifndef TCICT_SKIP_CLOSE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor1 = tci::eye<TenT>(ctx, 2);
@@ -43,14 +42,15 @@ void test_close_different(tci_test_fixture<TenT> &fix) {
 
   bool are_equal = tci::close(ctx, tensor1, tensor2, eps);
   TCICT_ASSERT(are_equal == false);
+#else
+  (void)fix;
+#endif
 }
 
 // --- to_range ---
 
 template <typename TenT> void test_to_range(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TO_RANGE
-  return;
-#endif
+#ifndef TCICT_SKIP_TO_RANGE
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -74,26 +74,28 @@ template <typename TenT> void test_to_range(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(real_part<TenT>(container[i]), static_cast<double>(i),
                        eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- show (does not throw) ---
 
 template <typename TenT> void test_show(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SHOW
-  return;
-#endif
+#ifndef TCICT_SKIP_SHOW
   auto &ctx = fix.context();
   auto a = tci::eye<TenT>(ctx, 2);
   TCICT_ASSERT_NOTHROW(tci::show(ctx, a));
+#else
+  (void)fix;
+#endif
 }
 
 // --- convert (same context) ---
 
 template <typename TenT>
 void test_convert_same_context(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONVERT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONVERT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::eye<TenT>(ctx, 3);
@@ -107,15 +109,16 @@ void test_convert_same_context(tci_test_fixture<TenT> &fix) {
   TenT original_b = tci::copy(ctx, b);
   tci::set_elem(ctx, a, {0, 0}, make_elem<TenT>(999.0));
   TCICT_ASSERT(tci::close(ctx, b, original_b, eps));
+#else
+  (void)fix;
+#endif
 }
 
 // --- convert (different contexts) ---
 
 template <typename TenT>
 void test_convert_different_context(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONVERT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONVERT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::eye<TenT>(ctx, 3);
@@ -129,15 +132,16 @@ void test_convert_different_context(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(tci::shape(ctx, a) == tci::shape(ctx, b));
 
   tci::destroy_context(ctx2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- convert (data integrity) ---
 
 template <typename TenT>
 void test_convert_data_integrity(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONVERT
-  return;
-#endif
+#ifndef TCICT_SKIP_CONVERT
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 3});
@@ -161,14 +165,15 @@ void test_convert_data_integrity(tci_test_fixture<TenT> &fix) {
   }
 
   tci::destroy_context(ctx2);
+#else
+  (void)fix;
+#endif
 }
 
 // --- version ---
 
 template <typename TenT> void test_version(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_VERSION
-  return;
-#endif
+#ifndef TCICT_SKIP_VERSION
   std::string ver = tci::template version<TenT>();
   TCICT_ASSERT(!ver.empty());
   // Version string should contain digits and a dot
@@ -176,6 +181,9 @@ template <typename TenT> void test_version(tci_test_fixture<TenT> &fix) {
       (ver.find_first_of("0123456789") != std::string::npos) &&
       (ver.find('.') != std::string::npos);
   TCICT_ASSERT(has_version_pattern);
+#else
+  (void)fix;
+#endif
 }
 
 } // namespace tests

--- a/include/tcict/tests/read_only_getters.h
+++ b/include/tcict/tests/read_only_getters.h
@@ -100,3 +100,13 @@ void test_size_bytes_2x2(tci_test_fixture<TenT>& fix) {
 }
 
 }}  // namespace tcict::tests
+
+// Bulk registration helper: invokes X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+#define TCICT_FOREACH_READ_ONLY_GETTERS_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "read_only_getters", test_order) \
+  X(__VA_ARGS__, "read_only_getters", test_shape) \
+  X(__VA_ARGS__, "read_only_getters", test_size) \
+  X(__VA_ARGS__, "read_only_getters", test_size_bytes) \
+  X(__VA_ARGS__, "read_only_getters", test_set_get_elem) \
+  X(__VA_ARGS__, "read_only_getters", test_size_bytes_2x2)

--- a/include/tcict/tests/read_only_getters.h
+++ b/include/tcict/tests/read_only_getters.h
@@ -13,21 +13,20 @@ namespace tcict { namespace tests {
 
 template <typename TenT>
 void test_order(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_ORDER
-  return;
-#endif
+#ifndef TCICT_SKIP_ORDER
   auto& ctx = fix.context();
   auto tensor = tci::zeros<TenT>(ctx, {2, 3, 4});
   TCICT_ASSERT(tci::order(ctx, tensor) == 3);
+#else
+  (void)fix;
+#endif
 }
 
 // --- shape ---
 
 template <typename TenT>
 void test_shape(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_SHAPE
-  return;
-#endif
+#ifndef TCICT_SKIP_SHAPE
   auto& ctx = fix.context();
   auto tensor = tci::zeros<TenT>(ctx, {2, 3, 4});
   auto result_shape = tci::shape(ctx, tensor);
@@ -35,42 +34,45 @@ void test_shape(tci_test_fixture<TenT>& fix) {
   TCICT_ASSERT(result_shape[0] == 2);
   TCICT_ASSERT(result_shape[1] == 3);
   TCICT_ASSERT(result_shape[2] == 4);
+#else
+  (void)fix;
+#endif
 }
 
 // --- size ---
 
 template <typename TenT>
 void test_size(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_SIZE
-  return;
-#endif
+#ifndef TCICT_SKIP_SIZE
   auto& ctx = fix.context();
   auto tensor = tci::zeros<TenT>(ctx, {2, 3, 4});
   TCICT_ASSERT(tci::size(ctx, tensor) == 24);
+#else
+  (void)fix;
+#endif
 }
 
 // --- size_bytes ---
 
 template <typename TenT>
 void test_size_bytes(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_SIZE_BYTES
-  return;
-#endif
+#ifndef TCICT_SKIP_SIZE_BYTES
   auto& ctx = fix.context();
   auto tensor = tci::zeros<TenT>(ctx, {2, 3, 4});
   auto bytes = tci::size_bytes(ctx, tensor);
   TCICT_ASSERT(bytes > 0);
   // Verify: 24 elements * sizeof(elem_t<TenT>)
   TCICT_ASSERT(bytes == 24 * sizeof(tci::elem_t<TenT>));
+#else
+  (void)fix;
+#endif
 }
 
 // --- get_elem / set_elem ---
 
 template <typename TenT>
 void test_set_get_elem(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_GET_ELEM
-  return;
-#endif
+#if !defined(TCICT_SKIP_GET_ELEM) && !defined(TCICT_SKIP_SET_ELEM)
   auto& ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
@@ -84,19 +86,23 @@ void test_set_get_elem(tci_test_fixture<TenT>& fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(retrieved), imag_part<TenT>(expected), eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- size_bytes for small tensor ---
 
 template <typename TenT>
 void test_size_bytes_2x2(tci_test_fixture<TenT>& fix) {
-#ifdef TCICT_SKIP_SIZE_BYTES
-  return;
-#endif
+#ifndef TCICT_SKIP_SIZE_BYTES
   auto& ctx = fix.context();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
   auto size = tci::size_bytes(ctx, tensor);
   TCICT_ASSERT(size > 0);
+#else
+  (void)fix;
+#endif
 }
 
 }}  // namespace tcict::tests

--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -970,3 +970,54 @@ template <typename TenT> void test_stack_errors(tci_test_fixture<TenT> &fix) {
 
 } // namespace tests
 } // namespace tcict
+
+// Bulk registration helpers: invoke X(..., "category", test_fn) once per test.
+// See include/tcict/adapters/doctest.h for usage.
+//
+// ALL_TYPES: safe for both real and complex TenT (imag-part assertions are
+//   dual-guarded via `if constexpr (is_complex_v<TenT>)`).
+#define TCICT_FOREACH_TENSOR_MANIPULATION_TEST_ALL_TYPES(X, ...) \
+  X(__VA_ARGS__, "tensor_manipulation", test_shrink_inplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_shrink_outofplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_shrink_complex_values) \
+  X(__VA_ARGS__, "tensor_manipulation", test_real_extraction) \
+  X(__VA_ARGS__, "tensor_manipulation", test_imag_extraction) \
+  X(__VA_ARGS__, "tensor_manipulation", test_real_imag_inplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_cplx_conj_inplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_cplx_conj_outofplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_doubling) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_summation) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_capture) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_const) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_inversion) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_with_coors) \
+  X(__VA_ARGS__, "tensor_manipulation", test_for_each_with_coors_const) \
+  X(__VA_ARGS__, "tensor_manipulation", test_reshape) \
+  X(__VA_ARGS__, "tensor_manipulation", test_transpose) \
+  X(__VA_ARGS__, "tensor_manipulation", test_concatenate_basic) \
+  X(__VA_ARGS__, "tensor_manipulation", test_concatenate_values) \
+  X(__VA_ARGS__, "tensor_manipulation", test_concatenate_errors) \
+  X(__VA_ARGS__, "tensor_manipulation", test_extract_sub) \
+  X(__VA_ARGS__, "tensor_manipulation", test_extract_sub_errors) \
+  X(__VA_ARGS__, "tensor_manipulation", test_replace_sub_inplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_replace_sub_outofplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_replace_sub_errors) \
+  X(__VA_ARGS__, "tensor_manipulation", test_expand_inplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_expand_outofplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_expand_invalid_throws) \
+  X(__VA_ARGS__, "tensor_manipulation", test_diag_vec_to_mat) \
+  X(__VA_ARGS__, "tensor_manipulation", test_diag_mat_to_vec) \
+  X(__VA_ARGS__, "tensor_manipulation", test_stack_basic) \
+  X(__VA_ARGS__, "tensor_manipulation", test_stack_last_axis) \
+  X(__VA_ARGS__, "tensor_manipulation", test_stack_errors)
+
+// REAL_ONLY: TCI `to_cplx` takes a real tensor and lifts to complex; these
+//   tests are only meaningful for real TenT.
+#define TCICT_FOREACH_TENSOR_MANIPULATION_TEST_REAL_ONLY(X, ...) \
+  X(__VA_ARGS__, "tensor_manipulation", test_to_cplx_outofplace) \
+  X(__VA_ARGS__, "tensor_manipulation", test_to_cplx_inplace)
+
+// CPLX_ONLY: body is wrapped in `if constexpr (is_complex_v<TenT>)`; running
+//   for real TenT would be a no-op, so skip registration.
+#define TCICT_FOREACH_TENSOR_MANIPULATION_TEST_CPLX_ONLY(X, ...) \
+  X(__VA_ARGS__, "tensor_manipulation", test_to_cplx_complex_to_complex)

--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -13,9 +13,7 @@ namespace tests {
 // --- shrink (in-place) ---
 
 template <typename TenT> void test_shrink_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SHRINK
-  return;
-#endif
+#ifndef TCICT_SKIP_SHRINK
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {3, 3});
@@ -49,15 +47,16 @@ template <typename TenT> void test_shrink_inplace(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 5.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- shrink (out-of-place) ---
 
 template <typename TenT>
 void test_shrink_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SHRINK
-  return;
-#endif
+#ifndef TCICT_SKIP_SHRINK
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto input = tci::zeros<TenT>(ctx, {4, 4});
@@ -88,15 +87,16 @@ void test_shrink_outofplace(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, output, {1, 1})), 22.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- shrink preserves complex values ---
 
 template <typename TenT>
 void test_shrink_complex_values(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_SHRINK
-  return;
-#endif
+#ifndef TCICT_SKIP_SHRINK
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {3, 3});
@@ -123,15 +123,16 @@ void test_shrink_complex_values(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(e00), 2.5, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(e01), 4.5, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- real extraction (out-of-place) ---
 
 template <typename TenT>
 void test_real_extraction(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_REAL
-  return;
-#endif
+#ifndef TCICT_SKIP_REAL
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
@@ -145,15 +146,16 @@ void test_real_extraction(tci_test_fixture<TenT> &fix) {
   auto elem11 = tci::get_elem(ctx, real_tensor, {1, 1});
   TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 3.14, eps);
   TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), -1.59, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- imag extraction (out-of-place) ---
 
 template <typename TenT>
 void test_imag_extraction(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_IMAG
-  return;
-#endif
+#ifndef TCICT_SKIP_IMAG
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
@@ -174,15 +176,16 @@ void test_imag_extraction(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem00), 0.0, eps);
     TCICT_ASSERT_CLOSE(real_part<RealTenT>(elem11), 0.0, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- real and imag extraction (in-place) ---
 
 template <typename TenT>
 void test_real_imag_inplace(tci_test_fixture<TenT> &fix) {
-#if defined(TCICT_SKIP_REAL) || defined(TCICT_SKIP_IMAG)
-  return;
-#endif
+#if !defined(TCICT_SKIP_REAL) && !defined(TCICT_SKIP_IMAG)
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
@@ -215,15 +218,16 @@ void test_real_imag_inplace(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(
         real_part<RealTenT>(tci::get_elem(ctx, imag_output, {1, 1})), 0.0, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- cplx_conj (in-place) ---
 
 template <typename TenT>
 void test_cplx_conj_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CPLX_CONJ
-  return;
-#endif
+#ifndef TCICT_SKIP_CPLX_CONJ
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto tensor = tci::zeros<TenT>(ctx, {2, 2});
@@ -254,15 +258,16 @@ void test_cplx_conj_inplace(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, tensor, {1, 1})), 8.0,
                        eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- cplx_conj (out-of-place) ---
 
 template <typename TenT>
 void test_cplx_conj_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CPLX_CONJ
-  return;
-#endif
+#ifndef TCICT_SKIP_CPLX_CONJ
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto input = tci::zeros<TenT>(ctx, {2, 2});
@@ -289,6 +294,9 @@ void test_cplx_conj_outofplace(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(tci::get_elem(ctx, output, {1, 1})), 1.73,
                        eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- to_cplx (out-of-place, from real type) ---
@@ -296,9 +304,7 @@ void test_cplx_conj_outofplace(tci_test_fixture<TenT> &fix) {
 
 template <typename RealTenT>
 void test_to_cplx_outofplace(tci_test_fixture<RealTenT> &fix) {
-#ifdef TCICT_SKIP_TO_CPLX
-  return;
-#endif
+#ifndef TCICT_SKIP_TO_CPLX
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   RealTenT real_tensor;
@@ -322,15 +328,16 @@ void test_to_cplx_outofplace(tci_test_fixture<RealTenT> &fix) {
   TCICT_ASSERT_CLOSE(imag_part<CplxTenT>(elem00), 0.0, eps);
   TCICT_ASSERT_CLOSE(real_part<CplxTenT>(elem11), 4.5, eps);
   TCICT_ASSERT_CLOSE(imag_part<CplxTenT>(elem11), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- to_cplx (in-place, from real type) ---
 
 template <typename RealTenT>
 void test_to_cplx_inplace(tci_test_fixture<RealTenT> &fix) {
-#ifdef TCICT_SKIP_TO_CPLX
-  return;
-#endif
+#ifndef TCICT_SKIP_TO_CPLX
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   RealTenT real_tensor;
@@ -351,15 +358,16 @@ void test_to_cplx_inplace(tci_test_fixture<RealTenT> &fix) {
   TCICT_ASSERT_CLOSE(imag_part<CplxTenT>(elem00), 0.0, eps);
   TCICT_ASSERT_CLOSE(real_part<CplxTenT>(elem11), 8.75, eps);
   TCICT_ASSERT_CLOSE(imag_part<CplxTenT>(elem11), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- to_cplx (complex to complex) ---
 
 template <typename TenT>
 void test_to_cplx_complex_to_complex(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TO_CPLX
-  return;
-#endif
+#ifndef TCICT_SKIP_TO_CPLX
   // For real TenT, tci::to_cplx returns cplx_ten_t<TenT> whose elements are
   // cplx_t<TenT>; calling imag_part<TenT>(cplx_elem) would be a type error.
   // This test therefore only runs when TenT is already complex.
@@ -379,15 +387,16 @@ void test_to_cplx_complex_to_complex(tci_test_fixture<TenT> &fix) {
     TCICT_ASSERT_CLOSE(real_part<TenT>(elem11), -1.41, eps);
     TCICT_ASSERT_CLOSE(imag_part<TenT>(elem11), 1.73, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each: element doubling ---
 
 template <typename TenT>
 void test_for_each_doubling(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -408,15 +417,16 @@ void test_for_each_doubling(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {1, 2})), 12.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each: iteration and summation ---
 
 template <typename TenT>
 void test_for_each_summation(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -436,15 +446,16 @@ void test_for_each_summation(tci_test_fixture<TenT> &fix) {
 
   TCICT_ASSERT(count == 4);
   TCICT_ASSERT_CLOSE(real_part<TenT>(sum), 10.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each: scalar multiplication with capture ---
 
 template <typename TenT>
 void test_for_each_capture(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -460,14 +471,15 @@ void test_for_each_capture(tci_test_fixture<TenT> &fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(result), 0.5, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each: const version ---
 
 template <typename TenT> void test_for_each_const(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -482,15 +494,16 @@ template <typename TenT> void test_for_each_const(tci_test_fixture<TenT> &fix) {
   if constexpr (is_complex_v<TenT>) {
     TCICT_ASSERT_CLOSE(imag_part<TenT>(sum), 9.0, eps);
   }
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each: element-wise inversion ---
 
 template <typename TenT>
 void test_for_each_inversion(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -505,15 +518,16 @@ void test_for_each_inversion(tci_test_fixture<TenT> &fix) {
 
   auto result = tci::get_elem(ctx, tensor, {0, 0});
   TCICT_ASSERT_CLOSE(real_part<TenT>(result), 2.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each_with_coors: mutable ---
 
 template <typename TenT>
 void test_for_each_with_coors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH_WITH_COORS
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH_WITH_COORS
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -528,15 +542,16 @@ void test_for_each_with_coors(tci_test_fixture<TenT> &fix) {
       });
 
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, a, {0, 0})), 2.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- for_each_with_coors: const version ---
 
 template <typename TenT>
 void test_for_each_with_coors_const(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_FOR_EACH_WITH_COORS
-  return;
-#endif
+#ifndef TCICT_SKIP_FOR_EACH_WITH_COORS
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   using Elem = tci::elem_t<TenT>;
@@ -554,14 +569,15 @@ void test_for_each_with_coors_const(tci_test_fixture<TenT> &fix) {
       });
 
   TCICT_ASSERT_CLOSE(sum_diagonal, 2.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- reshape (in-place) ---
 
 template <typename TenT> void test_reshape(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_RESHAPE
-  return;
-#endif
+#ifndef TCICT_SKIP_RESHAPE
   auto &ctx = fix.context();
   auto tensor = tci::fill<TenT>(ctx, {2, 3, 4}, make_elem<TenT>(1.0));
 
@@ -569,14 +585,15 @@ template <typename TenT> void test_reshape(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_NOTHROW(tci::reshape(ctx, tensor, new_shape));
   TCICT_ASSERT(tci::shape(ctx, tensor) == new_shape);
   TCICT_ASSERT(tci::size(ctx, tensor) == 24);
+#else
+  (void)fix;
+#endif
 }
 
 // --- transpose (out-of-place) ---
 
 template <typename TenT> void test_transpose(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_TRANSPOSE
-  return;
-#endif
+#ifndef TCICT_SKIP_TRANSPOSE
   auto &ctx = fix.context();
   auto tensor = tci::fill<TenT>(ctx, {2, 3, 4}, make_elem<TenT>(1.0));
 
@@ -586,15 +603,16 @@ template <typename TenT> void test_transpose(tci_test_fixture<TenT> &fix) {
 
   tci::shape_t<TenT> expected_shape = {4, 2, 3};
   TCICT_ASSERT(tci::shape(ctx, transposed) == expected_shape);
+#else
+  (void)fix;
+#endif
 }
 
 // --- concatenate: basic 2D ---
 
 template <typename TenT>
 void test_concatenate_basic(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONCATENATE
-  return;
-#endif
+#ifndef TCICT_SKIP_CONCATENATE
   auto &ctx = fix.context();
   auto t1 = tci::fill<TenT>(ctx, {2, 3}, make_elem<TenT>(1.0));
   auto t2 = tci::fill<TenT>(ctx, {2, 3}, make_elem<TenT>(2.0));
@@ -611,15 +629,16 @@ void test_concatenate_basic(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_NOTHROW(tci::concatenate(ctx, tensors, 1, result));
   tci::shape_t<TenT> expected_h = {2, 6};
   TCICT_ASSERT(tci::shape(ctx, result) == expected_h);
+#else
+  (void)fix;
+#endif
 }
 
 // --- concatenate: multi-tensor with value verification ---
 
 template <typename TenT>
 void test_concatenate_values(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONCATENATE
-  return;
-#endif
+#ifndef TCICT_SKIP_CONCATENATE
   auto &ctx = fix.context();
   auto a = tci::fill<TenT>(ctx, {2, 3, 4}, make_elem<TenT>(1.0));
   auto b = tci::fill<TenT>(ctx, {2, 1, 4}, make_elem<TenT>(2.0));
@@ -636,15 +655,16 @@ void test_concatenate_values(tci_test_fixture<TenT> &fix) {
   auto el_b = tci::get_elem(ctx, b, {0, 0, 0});
   auto el_d3 = tci::get_elem(ctx, d, {0, 3, 0});
   TCICT_ASSERT(el_b == el_d3);
+#else
+  (void)fix;
+#endif
 }
 
 // --- concatenate: error cases ---
 
 template <typename TenT>
 void test_concatenate_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_CONCATENATE
-  return;
-#endif
+#ifndef TCICT_SKIP_CONCATENATE
   auto &ctx = fix.context();
   auto tensor = tci::fill<TenT>(ctx, {2, 3, 4}, make_elem<TenT>(1.0));
 
@@ -656,14 +676,15 @@ void test_concatenate_errors(tci_test_fixture<TenT> &fix) {
   tci::List<TenT> empty;
   TCICT_ASSERT_THROWS(std::invalid_argument,
                       tci::concatenate(ctx, empty, 0, result));
+#else
+  (void)fix;
+#endif
 }
 
 // --- extract_sub (out-of-place) ---
 
 template <typename TenT> void test_extract_sub(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXTRACT_SUB
-  return;
-#endif
+#ifndef TCICT_SKIP_EXTRACT_SUB
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {3, 4, 2});
@@ -684,15 +705,16 @@ template <typename TenT> void test_extract_sub(tci_test_fixture<TenT> &fix) {
   // (2,1,1) in original maps to (1,1,1) in sub
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, sub, {1, 1, 1})), 13.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- extract_sub: error handling ---
 
 template <typename TenT>
 void test_extract_sub_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXTRACT_SUB
-  return;
-#endif
+#ifndef TCICT_SKIP_EXTRACT_SUB
   auto &ctx = fix.context();
   auto a = tci::zeros<TenT>(ctx, {3, 3});
 
@@ -705,15 +727,16 @@ void test_extract_sub_errors(tci_test_fixture<TenT> &fix) {
   tci::List<tci::Pair<tci::elem_coor_t<TenT>, tci::elem_coor_t<TenT>>>
       invalid_range = {{2, 1}, {0, 2}};
   TCICT_ASSERT_THROWS(std::exception, tci::extract_sub(ctx, a, invalid_range));
+#else
+  (void)fix;
+#endif
 }
 
 // --- replace_sub (in-place) ---
 
 template <typename TenT>
 void test_replace_sub_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_REPLACE_SUB
-  return;
-#endif
+#ifndef TCICT_SKIP_REPLACE_SUB
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {3, 4, 2});
@@ -730,15 +753,16 @@ void test_replace_sub_inplace(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, a, {0, 0, 0})), 0.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- replace_sub (out-of-place) ---
 
 template <typename TenT>
 void test_replace_sub_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_REPLACE_SUB
-  return;
-#endif
+#ifndef TCICT_SKIP_REPLACE_SUB
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {4, 4});
@@ -756,15 +780,16 @@ void test_replace_sub_outofplace(tci_test_fixture<TenT> &fix) {
                      eps);
   // Original unchanged
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, a, {1, 1})), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- replace_sub: error cases ---
 
 template <typename TenT>
 void test_replace_sub_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_REPLACE_SUB
-  return;
-#endif
+#ifndef TCICT_SKIP_REPLACE_SUB
   auto &ctx = fix.context();
   auto a = tci::zeros<TenT>(ctx, {3, 3});
 
@@ -775,14 +800,15 @@ void test_replace_sub_errors(tci_test_fixture<TenT> &fix) {
   // Out of bounds
   auto sub2 = tci::zeros<TenT>(ctx, {2, 2});
   TCICT_ASSERT_THROWS(std::exception, tci::replace_sub(ctx, a, sub2, {2, 2}));
+#else
+  (void)fix;
+#endif
 }
 
 // --- expand (in-place) ---
 
 template <typename TenT> void test_expand_inplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXPAND
-  return;
-#endif
+#ifndef TCICT_SKIP_EXPAND
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 2, 2});
@@ -796,15 +822,16 @@ template <typename TenT> void test_expand_inplace(tci_test_fixture<TenT> &fix) {
 
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, a, {2, 3, 0})), 0.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- expand (out-of-place) ---
 
 template <typename TenT>
 void test_expand_outofplace(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXPAND
-  return;
-#endif
+#ifndef TCICT_SKIP_EXPAND
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto a = tci::zeros<TenT>(ctx, {2, 2, 2});
@@ -821,29 +848,31 @@ void test_expand_outofplace(tci_test_fixture<TenT> &fix) {
                      5.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, expanded, {2, 3, 0})),
                      0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- expand: invalid bond throws ---
 
 template <typename TenT>
 void test_expand_invalid_throws(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_EXPAND
-  return;
-#endif
+#ifndef TCICT_SKIP_EXPAND
   auto &ctx = fix.context();
   auto a = tci::zeros<TenT>(ctx, {2, 2});
 
   tci::Map<tci::bond_idx_t<TenT>, tci::bond_dim_t<TenT>> invalid_map = {{3, 1}};
   TCICT_ASSERT_THROWS(std::exception, tci::expand(ctx, a, invalid_map));
+#else
+  (void)fix;
+#endif
 }
 
 // --- diag: vector to matrix ---
 
 template <typename TenT>
 void test_diag_vec_to_mat(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_DIAG
-  return;
-#endif
+#ifndef TCICT_SKIP_DIAG
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto vector = tci::zeros<TenT>(ctx, {3});
@@ -864,15 +893,16 @@ void test_diag_vec_to_mat(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, vector, {2, 2})), 3.0,
                      eps);
   TCICT_ASSERT_CLOSE(std::abs(tci::get_elem(ctx, vector, {0, 1})), 0.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- diag: matrix to vector ---
 
 template <typename TenT>
 void test_diag_mat_to_vec(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_DIAG
-  return;
-#endif
+#ifndef TCICT_SKIP_DIAG
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto identity = tci::eye<TenT>(ctx, 3);
@@ -887,14 +917,15 @@ void test_diag_mat_to_vec(tci_test_fixture<TenT> &fix) {
                      eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, identity, {2})), 1.0,
                      eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- stack: basic ---
 
 template <typename TenT> void test_stack_basic(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_STACK
-  return;
-#endif
+#ifndef TCICT_SKIP_STACK
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -920,15 +951,16 @@ template <typename TenT> void test_stack_basic(tci_test_fixture<TenT> &fix) {
                      2.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1, 2})),
                      2.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- stack: last axis ---
 
 template <typename TenT>
 void test_stack_last_axis(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_STACK
-  return;
-#endif
+#ifndef TCICT_SKIP_STACK
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -952,20 +984,24 @@ void test_stack_last_axis(tci_test_fixture<TenT> &fix) {
                      2.0, eps);
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 0, 2})),
                      3.0, eps);
+#else
+  (void)fix;
+#endif
 }
 
 // --- stack: errors ---
 
 template <typename TenT> void test_stack_errors(tci_test_fixture<TenT> &fix) {
-#ifdef TCICT_SKIP_STACK
-  return;
-#endif
+#ifndef TCICT_SKIP_STACK
   auto &ctx = fix.context();
 
   // Empty list
   TenT result;
   tci::List<TenT> empty;
   TCICT_ASSERT_THROWS(std::invalid_argument, tci::stack(ctx, empty, 0, result));
+#else
+  (void)fix;
+#endif
 }
 
 } // namespace tests


### PR DESCRIPTION
## Summary

- Add X-macro pattern (`TCICT_FOREACH_*_TEST_{ALL_TYPES,REAL_ONLY,CPLX_ONLY}`) to each `tests/*.h` so backends can iterate the full conformance test list mechanically.
- Aggregate per-header iterators in `include/tcict/tests/_list.h`.
- New `include/tcict/adapters/doctest.h` provides `TCICT_DOCTEST_REGISTER_REAL(tag, TenT)` and `TCICT_DOCTEST_REGISTER_CPLX(tag, TenT)` — register all applicable tests for one type variant in a single call.
- Existing `TCICT_DOCTEST_CASE` per-test API remains for fine-grained control.
- Closes #31.

## Test classification

- **ALL_TYPES** (107): real and complex are both safe (imag-part assertions are dual-guarded via `if constexpr (is_complex_v<TenT>)`).
- **REAL_ONLY** (2): `test_to_cplx_outofplace`, `test_to_cplx_inplace` — TCI `to_cplx` requires a real input.
- **CPLX_ONLY** (1): `test_to_cplx_complex_to_complex` — body is wrapped in `if constexpr (is_complex_v<TenT>)`; running for real `TenT` would be a redundant no-op.

## Test plan

- [x] Preprocessor smoke test confirms expansion counts: `REGISTER_REAL` emits 109 (107+2), `REGISTER_CPLX` emits 108 (107+1).
- [x] Compiled `bulk_conformance.cpp` against the cytnx backend (`TCICT_DOCTEST_REGISTER_REAL/CPLX(...)` for `RealTensor` and `CplxTensor`); object file generated with 217 unique `DOCTEST_ANON_FUNC_*` symbols (109+108) — no symbol collisions because doctest uses `__COUNTER__` for anonymous names on GCC/Clang/MSVC.
- [x] Existing `TCICT_DOCTEST_CASE` API unchanged — backwards-compatible.