### PR TITLE
feat(tolerance): add tol_category framework for backward-error scaling

### DIFF
--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -65,9 +65,9 @@ enum class tol_category {
 /// not yet realized in this implementation. The `N` parameter is reserved
 /// for future N-scaling of categories whose asymptotic growth is
 /// non-constant (reduction, factorization, iterative) and is currently
-/// ignored. Backends that need a different tolerance schedule specialize
-/// this free function template (or specialize the fixture's `epsilon()`,
-/// since the helper composes the result from `fix.epsilon()`).
+/// ignored. Backends that want a different tolerance schedule specialize
+/// the fixture's `epsilon()`; the helper composes its result from
+/// `fix.epsilon()`, so any backend-defined epsilon flows through.
 template <typename TenT>
 auto tolerance(tci_test_fixture<TenT>& fix, tol_category cat,
                std::size_t /*N*/ = 1) -> tci::real_t<TenT> {
@@ -84,8 +84,11 @@ auto tolerance(tci_test_fixture<TenT>& fix, tol_category cat,
       return eps * real_type{100};
     case tol_category::iterative:
       return eps * real_type{100};
+    default:
+      // Defensive fallback for out-of-range `tol_category` values produced by
+      // a `static_cast` from an integer that does not match a named case.
+      return eps;
   }
-  return eps;  // unreachable; switch is exhaustive over all enum values
 }
 
 }  // namespace tcict

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -26,7 +26,7 @@ struct tci_test_fixture {
   /// The known-type branches match values empirically sufficient for the
   /// small test fixtures in this suite; the fallback scales machine epsilon
   /// to absorb O(N) accumulation errors for unfamiliar real_t types.
-  auto epsilon() -> tci::real_t<TenT> {
+  auto epsilon() const -> tci::real_t<TenT> {
     using real_type = tci::real_t<TenT>;
     if constexpr (std::is_same_v<real_type, float>) {
       return 1e-5F;
@@ -58,14 +58,17 @@ enum class tol_category {
 
 /// Comparison tolerance for an operation in a given backward-error category.
 ///
-/// `N` is reserved for future N-scaling of factorization / iterative
-/// tolerances and is currently ignored; v1 returns category-specific
-/// constants that match the test suite's pre-existing hardcoded multipliers.
-/// Backends that need a different tolerance schedule specialize this free
-/// function template (or specialize the fixture's `epsilon()`, since the
-/// helper composes the result from `fix.epsilon()`).
+/// Currently returns category-specific constants that match the test
+/// suite's pre-existing hardcoded multipliers; the asymptotic scalings
+/// claimed in `tol_category`'s docstrings are the *target* error classes,
+/// not yet realized in this implementation. The `N` parameter is reserved
+/// for future N-scaling of categories whose asymptotic growth is
+/// non-constant (reduction, factorization, iterative) and is currently
+/// ignored. Backends that need a different tolerance schedule specialize
+/// this free function template (or specialize the fixture's `epsilon()`,
+/// since the helper composes the result from `fix.epsilon()`).
 template <typename TenT>
-auto tolerance(tci_test_fixture<TenT>& fix, tol_category cat,
+auto tolerance(const tci_test_fixture<TenT>& fix, tol_category cat,
                std::size_t /*N*/ = 1) -> tci::real_t<TenT> {
   using real_type = tci::real_t<TenT>;
   const auto eps = fix.epsilon();

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -9,9 +9,7 @@
 namespace tcict {
 
 /// Test fixture that manages a TCI context.
-/// Backends may specialize this for custom context creation (e.g. GPU) or
-/// epsilon. Specializations must declare `epsilon()` as a const member,
-/// because `tcict::tolerance` takes the fixture by `const&`.
+/// Backends may specialize this for custom context creation (e.g. GPU) or epsilon.
 template <typename TenT>
 struct tci_test_fixture {
   tci::context_handle_t<TenT> ctx;
@@ -28,7 +26,7 @@ struct tci_test_fixture {
   /// The known-type branches match values empirically sufficient for the
   /// small test fixtures in this suite; the fallback scales machine epsilon
   /// to absorb O(N) accumulation errors for unfamiliar real_t types.
-  auto epsilon() const -> tci::real_t<TenT> {
+  auto epsilon() -> tci::real_t<TenT> {
     using real_type = tci::real_t<TenT>;
     if constexpr (std::is_same_v<real_type, float>) {
       return 1e-5F;
@@ -71,7 +69,7 @@ enum class tol_category {
 /// this free function template (or specialize the fixture's `epsilon()`,
 /// since the helper composes the result from `fix.epsilon()`).
 template <typename TenT>
-auto tolerance(const tci_test_fixture<TenT>& fix, tol_category cat,
+auto tolerance(tci_test_fixture<TenT>& fix, tol_category cat,
                std::size_t /*N*/ = 1) -> tci::real_t<TenT> {
   using real_type = tci::real_t<TenT>;
   const auto eps = fix.epsilon();

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -43,8 +43,9 @@ struct tci_test_fixture {
 };
 
 /// Backward-error categories for numerical comparisons. Tolerances scale with
-/// the operation's expected error growth (Higham, Accuracy and Stability of
-/// Numerical Algorithms, 2nd ed.).
+/// the operation's expected error growth; see the LAPACK Users' Guide,
+/// Chapter 4 "Accuracy and Stability" (https://www.netlib.org/lapack/lug/)
+/// for the standard schedule.
 enum class tol_category {
   /// No floating-point arithmetic (copy, reshape, fill, zeros, eye).
   exact,

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -9,7 +9,9 @@
 namespace tcict {
 
 /// Test fixture that manages a TCI context.
-/// Backends may specialize this for custom context creation (e.g. GPU) or epsilon.
+/// Backends may specialize this for custom context creation (e.g. GPU) or
+/// epsilon. Specializations must declare `epsilon()` as a const member,
+/// because `tcict::tolerance` takes the fixture by `const&`.
 template <typename TenT>
 struct tci_test_fixture {
   tci::context_handle_t<TenT> ctx;

--- a/include/tcict/fixture.h
+++ b/include/tcict/fixture.h
@@ -2,6 +2,7 @@
 
 #include <tci/tensor_traits.h>
 
+#include <cstddef>
 #include <limits>
 #include <type_traits>
 
@@ -38,5 +39,49 @@ struct tci_test_fixture {
     }
   }
 };
+
+/// Backward-error categories for numerical comparisons. Tolerances scale with
+/// the operation's expected error growth (Higham, Accuracy and Stability of
+/// Numerical Algorithms, 2nd ed.).
+enum class tol_category {
+  /// No floating-point arithmetic (copy, reshape, fill, zeros, eye).
+  exact,
+  /// O(eps): single multiply / assignment (scale, set_elem / get_elem).
+  elementwise,
+  /// O(sqrt(N) * eps): pairwise / Kahan summation (norm, trace, linear_combine).
+  reduction,
+  /// O(N * eps * cond): BLAS / LAPACK backward stability (QR, LQ, SVD, eig, eigh).
+  factorization,
+  /// O(N^k * eps): algorithm-dependent composite (exp, inverse).
+  iterative,
+};
+
+/// Comparison tolerance for an operation in a given backward-error category.
+///
+/// `N` is reserved for future N-scaling of factorization / iterative
+/// tolerances and is currently ignored; v1 returns category-specific
+/// constants that match the test suite's pre-existing hardcoded multipliers.
+/// Backends that need a different tolerance schedule specialize this free
+/// function template (or specialize the fixture's `epsilon()`, since the
+/// helper composes the result from `fix.epsilon()`).
+template <typename TenT>
+auto tolerance(tci_test_fixture<TenT>& fix, tol_category cat,
+               std::size_t /*N*/ = 1) -> tci::real_t<TenT> {
+  using real_type = tci::real_t<TenT>;
+  const auto eps = fix.epsilon();
+  switch (cat) {
+    case tol_category::exact:
+      return real_type{0};
+    case tol_category::elementwise:
+      return eps;
+    case tol_category::reduction:
+      return eps;
+    case tol_category::factorization:
+      return eps * real_type{100};
+    case tol_category::iterative:
+      return eps * real_type{100};
+  }
+  return eps;  // unreachable; switch is exhaustive over all enum values
+}
 
 }  // namespace tcict

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -345,7 +345,6 @@ void test_contract_outer_product(tci_test_fixture<TenT> &fix) {
 template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_QR
   auto &ctx = fix.context();
-  auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
   for (int i = 0; i < 3; ++i)
     for (int j = 0; j < 3; ++j)
@@ -362,7 +361,8 @@ template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
   // Verify Q * R ≈ A (reconstruction)
   TenT reconstructed;
   tci::contract(ctx, q, "ij", r, "jk", reconstructed, "ik");
-  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix, eps * 100));
+  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix,
+                          tolerance(fix, tol_category::factorization)));
 
   // Verify Q†Q ≈ I (orthogonality)
   TenT q_dag;
@@ -373,7 +373,8 @@ template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
   tci::contract(ctx, q_dag_t, "ij", q, "jk", qtq, "ik");
   auto bond_dim = tci::shape(ctx, q)[1];
   auto identity = tci::eye<TenT>(ctx, bond_dim);
-  TCICT_ASSERT(tci::close(ctx, qtq, identity, eps * 100));
+  TCICT_ASSERT(tci::close(ctx, qtq, identity,
+                          tolerance(fix, tol_category::factorization)));
 #else
   (void)fix;
 #endif
@@ -384,7 +385,6 @@ template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
 template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_LQ
   auto &ctx = fix.context();
-  auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
   for (int i = 0; i < 3; ++i)
     for (int j = 0; j < 3; ++j)
@@ -401,7 +401,8 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
   // Verify L * Q ≈ A (reconstruction)
   TenT reconstructed;
   tci::contract(ctx, l, "ij", q, "jk", reconstructed, "ik");
-  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix, eps * 100));
+  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix,
+                          tolerance(fix, tol_category::factorization)));
 
   // Verify QQ† ≈ I (orthogonality)
   TenT q_dag;
@@ -412,7 +413,8 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
   tci::contract(ctx, q, "ij", q_dag_t, "jk", qqt, "ik");
   auto bond_dim = tci::shape(ctx, q)[0];
   auto identity = tci::eye<TenT>(ctx, bond_dim);
-  TCICT_ASSERT(tci::close(ctx, qqt, identity, eps * 100));
+  TCICT_ASSERT(tci::close(ctx, qqt, identity,
+                          tolerance(fix, tol_category::factorization)));
 #else
   (void)fix;
 #endif
@@ -660,7 +662,7 @@ template <typename TenT>
 void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
   auto &ctx = fix.context();
-  auto eps = fix.epsilon();
+  auto tol = tolerance(fix, tol_category::iterative);
   auto anti_herm = tci::zeros<TenT>(ctx, {2, 2});
   tci::set_elem(ctx, anti_herm, {0, 1}, make_elem<TenT>(1.0));
   tci::set_elem(ctx, anti_herm, {1, 0}, make_elem<TenT>(-1.0));
@@ -671,14 +673,10 @@ void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
   // exp([[0,1],[-1,0]]) = [[cos(1), sin(1)], [-sin(1), cos(1)]]
   auto c = std::cos(1.0);
   auto s = std::sin(1.0);
-  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 0})), c,
-                     eps * 100);
-  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 1})), s,
-                     eps * 100);
-  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 0})), -s,
-                     eps * 100);
-  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), c,
-                     eps * 100);
+  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 0})), c, tol);
+  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {0, 1})), s, tol);
+  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 0})), -s, tol);
+  TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, result, {1, 1})), c, tol);
 #else
   (void)fix;
 #endif
@@ -887,7 +885,6 @@ template <typename TenT>
 void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_SVD
   auto &ctx = fix.context();
-  auto eps = fix.epsilon();
 
   // [[1,2],[3,4]]
   auto matrix = tci::zeros<TenT>(ctx, {2, 2});
@@ -919,7 +916,8 @@ void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
   TenT reconstructed;
   tci::contract(ctx, u_scaled, "ik", v_dag, "kj", reconstructed, "ij");
 
-  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix, eps * 100));
+  TCICT_ASSERT(tci::close(ctx, reconstructed, matrix,
+                          tolerance(fix, tol_category::factorization)));
 #else
   (void)fix;
 #endif


### PR DESCRIPTION
## Summary

Introduces a `tol_category` enum and a `tolerance(fix, cat, N=1)` free function template so that each numerical-test tolerance expresses **what error class** it tolerates rather than carrying an unexplained `eps * 100` literal. The category schedule follows the [LAPACK Users' Guide, Chapter 4 "Accuracy and Stability"](https://www.netlib.org/lapack/lug/): `exact / elementwise / reduction / factorization / iterative`.

This PR introduces the framework and migrates the 9 existing `eps * 100` callsites in `linear_algebra.h`. The framework preserves the existing numerical semantics exactly: both `factorization` and `iterative` still return `eps * 100` in v1.

## Why a free function (not a fixture method)

A method on the primary `tci_test_fixture<TenT>` template would not be inherited by explicit specializations. The fixture's documented extension point is "Backends may specialize this for custom context creation (e.g. GPU) or epsilon" — a backend specialization that overrides `epsilon()` would silently lack a `tolerance()` method, breaking every callsite. A free function template that takes the fixture and calls `fix.epsilon()` works against any fixture (primary or specialized) because `epsilon()` is what backends are already documented to provide.

## Migrated callsites

| Test | Sites | Category |
|---|---|---|
| `test_qr` | 2 | `factorization` |
| `test_lq` | 2 | `factorization` |
| `test_svd_reconstruction` | 1 | `factorization` |
| `test_exp_anti_hermitian` | 4 | `iterative` |

Total: 9. The 4 now-unused `auto eps = fix.epsilon();` declarations in those functions are removed.

## What is *not* in this PR (deferred)

- Empirical calibration of the multipliers across BLAS implementations
- N-scaling implementation (the helper accepts `N` but ignores it)
- Migration of the 308 bare-`eps` callsites (semantically equivalent to `tolerance(elementwise)`)
- Backend override mechanisms beyond fixture / free-function specialization

These all appear in the `Inconclusive / Deferred items` section of the plan posted to issue #32.

## Test plan

- [x] `make integration-test` against the cytnx backend: 6293 assertions pass; 3 pre-existing test-case failures (in `test_save_load_roundtrip`, `test_load_integrity`, and a `tci::order` assertion at `linear_algebra.h:837`) reproduce on `main` and are not affected by this change.
- [x] codex review on the branch diff returned no findings.

Refs #32.

