### PR TITLE
fix(tests): make for_each scalar arithmetic typeable for complex<float>

### DIFF
--- a/include/tcict/tests/tensor_manipulation.h
+++ b/include/tcict/tests/tensor_manipulation.h
@@ -409,7 +409,8 @@ void test_for_each_doubling(tci_test_fixture<TenT> &fix) {
   tci::set_elem(ctx, tensor, {1, 1}, make_elem<TenT>(5.0));
   tci::set_elem(ctx, tensor, {1, 2}, make_elem<TenT>(6.0));
 
-  tci::for_each(ctx, tensor, [](Elem &elem) { elem = elem * 2.0; });
+  tci::for_each(ctx, tensor,
+                [](Elem &elem) { elem = elem * make_elem<TenT>(2.0); });
 
   TCICT_ASSERT_CLOSE(real_part<TenT>(tci::get_elem(ctx, tensor, {0, 0})), 2.0,
                      eps);
@@ -462,7 +463,7 @@ void test_for_each_capture(tci_test_fixture<TenT> &fix) {
 
   auto tensor = tci::fill<TenT>(ctx, {2, 2}, make_elem<TenT>(3.0, 1.0));
 
-  double multiplier = 0.5;
+  auto multiplier = make_elem<TenT>(0.5);
   tci::for_each(ctx, tensor,
                 [multiplier](Elem &elem) { elem = elem * multiplier; });
 


### PR DESCRIPTION
## Summary

`test_for_each_doubling` and `test_for_each_capture` multiplied an `Elem` value (`tci::elem_t<TenT>`) by a `double` literal. C++ resolves this against the `std::complex<T> * T` operator, which works for `std::complex<double>` because `T = double`, but fails to instantiate for `std::complex<float>` because the `double` operand cannot be deduced as `T = float` and is not an exact match for any other overload. The result was a hard compile error every time a backend registered a `complex<float>` instance.

This PR constructs the multiplier through `make_elem<TenT>` instead, the pattern the rest of the file already uses for typed literals.

## Changes

- `include/tcict/tests/tensor_manipulation.h:412` — `elem * 2.0` → `elem * make_elem<TenT>(2.0)`
- `include/tcict/tests/tensor_manipulation.h:467` — `double multiplier = 0.5` → `auto multiplier = make_elem<TenT>(0.5)`

Numerically identical for `complex<double>` and the real types; new types `float` and `complex<float>` now compile.

## Test plan

Verified empirically against the cytnx backend (with cytnx_float / cytnx_complex64 instances registered through the bulk macros):

- before fix: `complex<float>` instantiation produced 2 cascading `error: invalid operands to binary expression ('Elem' (aka 'std::complex<float>') and 'double')` errors blocking compile.
- after fix: build is clean; the suite expands from 243 to 460 test cases (4 type variants × ~115 tests). No new compile errors. 41 runtime failures observed are pre-existing cytnx-side bugs (real-input `tci::exp`, file-ordering `tci::load`, real-input `tci::trace`) and float/complex64-precision tolerance issues — independent of this fix and tracked separately.

The change does not require new tests because the fix's correctness is exactly the compile-time success it produces; the existing tests now run with previously-uninstantiable element types.
