### PR TITLE
feat(skip): add per-API single-precision skip macros for factorization/iterative tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ A skipped test still compiles, registers as a test case, and immediately passes 
 
 A backend that does not provide these cannot use TCICT at all, with or without skip macros.
 
+### 5. Skip tests for a specific precision (known precision-specific bugs)
+
+For factorization / iterative APIs where a backend has a known **precision-specific runtime bug** (e.g., a single-precision `eig` that compiles fine but returns wrong values), define the corresponding `TCICT_SKIP_<API>_SINGLE_PRECISION` macro to skip those tests **only for single-precision instantiations** (TenT whose `tci::real_t<TenT>` is `float`, covering both `float` and `std::complex<float>`):
+
+```cmake
+target_compile_definitions(my_tests PRIVATE
+    TCICT_SKIP_EIG_SINGLE_PRECISION
+    TCICT_SKIP_EIGH_SINGLE_PRECISION
+)
+```
+
+The corresponding double-precision instantiations continue to run.
+
+Available flags (10 APIs covered, factorization + iterative classes per `fixture.h`):
+
+- `TCICT_SKIP_EIG_SINGLE_PRECISION`, `TCICT_SKIP_EIGH_SINGLE_PRECISION`
+- `TCICT_SKIP_EIGVALS_SINGLE_PRECISION`, `TCICT_SKIP_EIGVALSH_SINGLE_PRECISION`
+- `TCICT_SKIP_SVD_SINGLE_PRECISION`, `TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION`
+- `TCICT_SKIP_QR_SINGLE_PRECISION`, `TCICT_SKIP_LQ_SINGLE_PRECISION`
+- `TCICT_SKIP_EXP_SINGLE_PRECISION`, `TCICT_SKIP_INVERSE_SINGLE_PRECISION`
+
+**Different semantics from `TCICT_SKIP_<API>`.** Whole-API skip in section 4 excludes the test body **at preprocessing time** (`#ifndef`), so the API call disappears from the translation unit entirely. Precision skip is an **`if constexpr`-guarded runtime early return**: the body is still part of the function template and gets instantiated for every TenT, including the single-precision ones. API calls inside the body must therefore be valid for that precision at compile time.
+
+This handles backends with runtime-buggy APIs (the call compiles but produces wrong values). For backends that intentionally make a (API × precision) combination compile-time-unavailable (via SFINAE / `static_assert` / `= delete`), use the whole-API `TCICT_SKIP_<API>` macro instead. A compile-time body-discard variant is planned (see [#50](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/50)).
+
 ## Test Categories
 
 | Category | Header | Functions exercised |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Available flags (10 APIs covered, factorization + iterative classes per `fixture
 - `TCICT_SKIP_QR_SINGLE_PRECISION`, `TCICT_SKIP_LQ_SINGLE_PRECISION`
 - `TCICT_SKIP_EXP_SINGLE_PRECISION`, `TCICT_SKIP_INVERSE_SINGLE_PRECISION`
 
-**Different semantics from `TCICT_SKIP_<API>`.** Whole-API skip in section 4 excludes the test body **at preprocessing time** (`#ifndef`), so the API call disappears from the translation unit entirely. Precision skip is an **`if constexpr`-guarded runtime early return**: the body is still part of the function template and gets instantiated for every TenT, including the single-precision ones. API calls inside the body must therefore be valid for that precision at compile time.
+**Different semantics from `TCICT_SKIP_<API>`.** Whole-API skip in section 4 excludes the test body **at preprocessing time** (`#ifndef`), so the API call disappears from that guarded test's body (other tests that reference the same `tci::*` API as a helper / setup still compile against it; see the per-test caveat in section 4). Precision skip is an **`if constexpr`-guarded runtime early return**: the body is still part of the function template and gets instantiated for every TenT, including the single-precision ones. API calls inside the body must therefore be valid for that precision at compile time.
 
 This handles backends with runtime-buggy APIs (the call compiles but produces wrong values). For backends that intentionally make a (API × precision) combination compile-time-unavailable (via SFINAE / `static_assert` / `= delete`), use the whole-API `TCICT_SKIP_<API>` macro instead. A compile-time body-discard variant is planned (see [#50](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/50)).
 

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -47,43 +47,52 @@
 //
 // Precision-conditional skip macros (factorization + iterative APIs):
 //
-// When defined, the corresponding test functions emit an `if constexpr`-
-// guarded early return that fires for single-precision instantiations
-// (real_t<TenT> == float, covering both `float` and `std::complex<float>`).
-// The condition is evaluated at compile time, so the return is compiled
-// out for double-precision instantiations (zero runtime cost); for the
-// matching single-precision instantiations, the return executes at
-// function entry and the assertions below are not reached. See the
-// Limitation note below on body instantiation semantics. Useful when a
-// backend has known precision-specific bugs (e.g., a buggy single-
-// precision LAPACK eig) that are difficult to fix and the goal is to
-// keep the suite green for double precision while flagging single
+// When the corresponding TCICT_SKIP_<API>_SINGLE_PRECISION macro is
+// defined, the matching test function expands TCICT_RETURN_IF_SINGLE_PRECISION
+// at the top of its body. That helper is an `if constexpr`-guarded early
+// return: when the test is instantiated for a TenT whose
+// `tci::real_t<TenT>` is `float` (covering both `float` and
+// `std::complex<float>` element types), the return statement executes
+// before any assertion runs; for other instantiations (`real_t<TenT>` is
+// `double` or `long double`), the `if constexpr`'s discarded-statement
+// rule means the return is compiled out entirely (zero runtime cost).
+//
+// Useful when a backend has known precision-specific bugs (e.g., a buggy
+// single-precision LAPACK eig) that are difficult to fix, and the goal
+// is to keep the suite green for double precision while flagging single
 // precision separately.
 //
+// Available per-API gating macros (10 total, defined by the backend):
 //   TCICT_SKIP_EIG_SINGLE_PRECISION,    TCICT_SKIP_EIGH_SINGLE_PRECISION,
 //   TCICT_SKIP_EIGVALS_SINGLE_PRECISION, TCICT_SKIP_EIGVALSH_SINGLE_PRECISION,
 //   TCICT_SKIP_SVD_SINGLE_PRECISION,    TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION,
 //   TCICT_SKIP_QR_SINGLE_PRECISION,     TCICT_SKIP_LQ_SINGLE_PRECISION,
 //   TCICT_SKIP_EXP_SINGLE_PRECISION,    TCICT_SKIP_INVERSE_SINGLE_PRECISION
 //
-// Limitation: this is a *runtime* skip — the test body is still part of
-// the function template and gets instantiated for the matching precision.
-// API calls inside the body must be valid for that precision at compile
-// time. This pattern handles backends with runtime-buggy APIs (the call
-// compiles but returns wrong values, e.g., cytnx's single-precision eig).
-// For backends that intentionally make a (API × precision) combination
-// compile-time-unavailable (via SFINAE / static_assert / = delete), use
-// the whole-API TCICT_SKIP_<API> macro instead. A compile-time body-
-// discard variant is planned; see issue #50.
+// Limitation: this is a *runtime* skip path. The test body following the
+// helper is always part of the function template and gets instantiated
+// for every TenT, including the matching single-precision ones. API
+// calls inside the body must therefore be valid for that precision at
+// compile time. This pattern handles backends with runtime-buggy APIs
+// (the call compiles but returns wrong values, e.g., cytnx's
+// single-precision eig). For backends that intentionally make a
+// (API × precision) combination compile-time-unavailable (via SFINAE /
+// `static_assert` / `= delete`), use the whole-API TCICT_SKIP_<API>
+// macro instead. A compile-time body-discard variant is planned; see
+// issue #50.
 
-// Compile-time-evaluated early return when `tci::real_t<TenT>` is `float`
-// (i.e., TenT's real precision is single — covering both `float` and
-// `std::complex<float>` element types). Requires `TenT` to be the template
-// parameter of the enclosing function and `tci::real_t<TenT>` to be in
-// scope (brought in by tcict/fixture.h via <tci/tensor_traits.h>). Used
-// inside test bodies, gated by per-API TCICT_SKIP_*_SINGLE_PRECISION
-// flags. See the Limitation note above on runtime-vs-compile-time skip
-// semantics.
+// `if constexpr`-guarded early return that fires when `tci::real_t<TenT>`
+// is `float` (i.e., TenT's real precision is single — covering both
+// `float` and `std::complex<float>` element types). Requires `TenT` to be
+// the template parameter of the enclosing function and `tci::real_t<TenT>`
+// to be in scope (brought in by tcict/fixture.h via
+// <tci/tensor_traits.h>). Used inside test bodies, gated by the per-API
+// TCICT_SKIP_*_SINGLE_PRECISION flags listed above. See the Limitation
+// note for the runtime-vs-compile-time skip caveat.
+//
+// The do-while(false) wrapper is macro hygiene: it lets callers append
+// the usual statement-terminating `;` and prevents dangling-else issues
+// when the helper is used inside an unbraced `if`/`else`.
 #define TCICT_RETURN_IF_SINGLE_PRECISION                                       \
   do {                                                                         \
     if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {                  \

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -59,11 +59,22 @@
 //   TCICT_SKIP_SVD_SINGLE_PRECISION,    TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION,
 //   TCICT_SKIP_QR_SINGLE_PRECISION,     TCICT_SKIP_LQ_SINGLE_PRECISION,
 //   TCICT_SKIP_EXP_SINGLE_PRECISION,    TCICT_SKIP_INVERSE_SINGLE_PRECISION
+//
+// Limitation: this is a *runtime* skip — the test body is still part of
+// the function template and gets instantiated for the matching precision.
+// API calls inside the body must be valid for that precision at compile
+// time. This pattern handles backends with runtime-buggy APIs (the call
+// compiles but returns wrong values, e.g., cytnx's single-precision eig).
+// For backends that intentionally make a (API × precision) combination
+// compile-time-unavailable (via SFINAE / static_assert / = delete), use
+// the whole-API TCICT_SKIP_<API> macro instead. A compile-time body-
+// discard variant is planned; see issue #50.
 
 // Compile-time-evaluated early return when the elem_t of TenT is single
 // precision. Requires `TenT` to be the template parameter of the enclosing
 // function and `tci::real_t<TenT>` to be in scope (via <tci/tci.h>). Used
 // inside test bodies, gated by per-API TCICT_SKIP_*_SINGLE_PRECISION flags.
+// See the Limitation note above on runtime-vs-compile-time skip semantics.
 #define TCICT_RETURN_IF_SINGLE_PRECISION                                       \
   do {                                                                         \
     if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {                  \

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -76,12 +76,14 @@
 // the whole-API TCICT_SKIP_<API> macro instead. A compile-time body-
 // discard variant is planned; see issue #50.
 
-// Compile-time-evaluated early return when the elem_t of TenT is single
-// precision. Requires `TenT` to be the template parameter of the enclosing
-// function and `tci::real_t<TenT>` to be in scope (brought in by
-// tcict/fixture.h via <tci/tensor_traits.h>). Used inside test bodies,
-// gated by per-API TCICT_SKIP_*_SINGLE_PRECISION flags. See the Limitation
-// note above on runtime-vs-compile-time skip semantics.
+// Compile-time-evaluated early return when `tci::real_t<TenT>` is `float`
+// (i.e., TenT's real precision is single — covering both `float` and
+// `std::complex<float>` element types). Requires `TenT` to be the template
+// parameter of the enclosing function and `tci::real_t<TenT>` to be in
+// scope (brought in by tcict/fixture.h via <tci/tensor_traits.h>). Used
+// inside test bodies, gated by per-API TCICT_SKIP_*_SINGLE_PRECISION
+// flags. See the Limitation note above on runtime-vs-compile-time skip
+// semantics.
 #define TCICT_RETURN_IF_SINGLE_PRECISION                                       \
   do {                                                                         \
     if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {                  \

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 // TCICT skip macros for unimplemented functions.
 //
 // Default: all tests are enabled (no skipping).
@@ -42,3 +44,29 @@
 // Miscellaneous:
 //   TCICT_SKIP_TO_RANGE, TCICT_SKIP_SHOW, TCICT_SKIP_CLOSE, TCICT_SKIP_CONVERT,
 //   TCICT_SKIP_VERSION
+//
+// Precision-conditional skip macros (factorization + iterative APIs):
+//
+// When defined, the corresponding test functions perform a compile-time
+// early return for single-precision instantiations (real_t<TenT> == float,
+// covering both `float` and `std::complex<float>`). Useful when a backend
+// has known precision-specific bugs (e.g., a buggy single-precision LAPACK
+// eig) that are difficult to fix and the goal is to keep the suite green
+// for double precision while flagging single precision separately.
+//
+//   TCICT_SKIP_EIG_SINGLE_PRECISION,    TCICT_SKIP_EIGH_SINGLE_PRECISION,
+//   TCICT_SKIP_EIGVALS_SINGLE_PRECISION, TCICT_SKIP_EIGVALSH_SINGLE_PRECISION,
+//   TCICT_SKIP_SVD_SINGLE_PRECISION,    TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION,
+//   TCICT_SKIP_QR_SINGLE_PRECISION,     TCICT_SKIP_LQ_SINGLE_PRECISION,
+//   TCICT_SKIP_EXP_SINGLE_PRECISION,    TCICT_SKIP_INVERSE_SINGLE_PRECISION
+
+// Compile-time-evaluated early return when the elem_t of TenT is single
+// precision. Requires `TenT` to be the template parameter of the enclosing
+// function and `tci::real_t<TenT>` to be in scope (via <tci/tci.h>). Used
+// inside test bodies, gated by per-API TCICT_SKIP_*_SINGLE_PRECISION flags.
+#define TCICT_RETURN_IF_SINGLE_PRECISION                                       \
+  do {                                                                         \
+    if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {                  \
+      return;                                                                  \
+    }                                                                          \
+  } while (false)

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -72,9 +72,10 @@
 
 // Compile-time-evaluated early return when the elem_t of TenT is single
 // precision. Requires `TenT` to be the template parameter of the enclosing
-// function and `tci::real_t<TenT>` to be in scope (via <tci/tci.h>). Used
-// inside test bodies, gated by per-API TCICT_SKIP_*_SINGLE_PRECISION flags.
-// See the Limitation note above on runtime-vs-compile-time skip semantics.
+// function and `tci::real_t<TenT>` to be in scope (brought in by
+// tcict/fixture.h via <tci/tensor_traits.h>). Used inside test bodies,
+// gated by per-API TCICT_SKIP_*_SINGLE_PRECISION flags. See the Limitation
+// note above on runtime-vs-compile-time skip semantics.
 #define TCICT_RETURN_IF_SINGLE_PRECISION                                       \
   do {                                                                         \
     if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {                  \

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -53,9 +53,10 @@
 // return: when the test is instantiated for a TenT whose
 // `tci::real_t<TenT>` is `float` (covering both `float` and
 // `std::complex<float>` element types), the return statement executes
-// before any assertion runs; for other instantiations (`real_t<TenT>` is
-// `double` or `long double`), the `if constexpr`'s discarded-statement
-// rule means the return is compiled out entirely (zero runtime cost).
+// before any assertion runs; for any other instantiation (`real_t<TenT>`
+// is anything other than `float`), the `if constexpr`'s discarded-
+// statement rule means the return is compiled out entirely (zero
+// runtime cost).
 //
 // Useful when a backend has known precision-specific bugs (e.g., a buggy
 // single-precision LAPACK eig) that are difficult to fix, and the goal

--- a/include/tcict/skip.h
+++ b/include/tcict/skip.h
@@ -47,12 +47,18 @@
 //
 // Precision-conditional skip macros (factorization + iterative APIs):
 //
-// When defined, the corresponding test functions perform a compile-time
-// early return for single-precision instantiations (real_t<TenT> == float,
-// covering both `float` and `std::complex<float>`). Useful when a backend
-// has known precision-specific bugs (e.g., a buggy single-precision LAPACK
-// eig) that are difficult to fix and the goal is to keep the suite green
-// for double precision while flagging single precision separately.
+// When defined, the corresponding test functions emit an `if constexpr`-
+// guarded early return that fires for single-precision instantiations
+// (real_t<TenT> == float, covering both `float` and `std::complex<float>`).
+// The condition is evaluated at compile time, so the return is compiled
+// out for double-precision instantiations (zero runtime cost); for the
+// matching single-precision instantiations, the return executes at
+// function entry and the assertions below are not reached. See the
+// Limitation note below on body instantiation semantics. Useful when a
+// backend has known precision-specific bugs (e.g., a buggy single-
+// precision LAPACK eig) that are difficult to fix and the goal is to
+// keep the suite green for double precision while flagging single
+// precision separately.
 //
 //   TCICT_SKIP_EIG_SINGLE_PRECISION,    TCICT_SKIP_EIGH_SINGLE_PRECISION,
 //   TCICT_SKIP_EIGVALS_SINGLE_PRECISION, TCICT_SKIP_EIGVALSH_SINGLE_PRECISION,

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -429,9 +429,6 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 // --- truncated SVD ---
 
 #ifndef TCICT_SKIP_TRUNC_SVD
-#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
-  TCICT_RETURN_IF_SINGLE_PRECISION;
-#endif
 // Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1].
 // Only defined when TRUNC_SVD tests are active so partial backends without
 // tci::zeros / tci::set_elem do not need to declare them.

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -344,6 +344,9 @@ void test_contract_outer_product(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_QR
+#ifdef TCICT_SKIP_QR_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
   for (int i = 0; i < 3; ++i)
@@ -384,6 +387,9 @@ template <typename TenT> void test_qr(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_LQ
+#ifdef TCICT_SKIP_LQ_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto matrix = tci::zeros<TenT>(ctx, {3, 3});
   for (int i = 0; i < 3; ++i)
@@ -423,6 +429,9 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 // --- truncated SVD ---
 
 #ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
 // Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1].
 // Only defined when TRUNC_SVD tests are active so partial backends without
 // tci::zeros / tci::set_elem do not need to declare them.
@@ -439,6 +448,9 @@ TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &
 
 template <typename TenT> void test_trunc_svd(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
 
@@ -466,6 +478,9 @@ template <typename TenT> void test_trunc_svd(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_trunc_svd_trunc_err_value(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -490,6 +505,9 @@ void test_trunc_svd_trunc_err_value(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_trunc_svd_trunc_err_no_truncation(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -515,6 +533,9 @@ void test_trunc_svd_trunc_err_no_truncation(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = trunc_svd_test_matrix<TenT>(ctx);
@@ -543,6 +564,9 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_eig_identity(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIG
+#ifdef TCICT_SKIP_EIG_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::eye<TenT>(ctx, 2);
@@ -568,6 +592,9 @@ template <typename TenT> void test_eig_identity(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_eigh_identity(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIGH
+#ifdef TCICT_SKIP_EIGH_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::eye<TenT>(ctx, 2);
@@ -594,6 +621,9 @@ template <typename TenT> void test_eigh_identity(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_exp_identity(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
+#ifdef TCICT_SKIP_EXP_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto identity = tci::eye<TenT>(ctx, 3);
@@ -615,6 +645,9 @@ template <typename TenT> void test_exp_identity(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_exp_diagonal(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
+#ifdef TCICT_SKIP_EXP_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto diagonal = tci::zeros<TenT>(ctx, {2, 2});
@@ -639,6 +672,9 @@ template <typename TenT> void test_exp_diagonal(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_exp_zero(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
+#ifdef TCICT_SKIP_EXP_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto zero_matrix = tci::zeros<TenT>(ctx, {2, 2});
@@ -661,6 +697,9 @@ template <typename TenT> void test_exp_zero(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
+#ifdef TCICT_SKIP_EXP_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto tol = tolerance(fix, tol_category::iterative);
   auto anti_herm = tci::zeros<TenT>(ctx, {2, 2});
@@ -686,6 +725,9 @@ void test_exp_anti_hermitian(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_exp_errors(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EXP
+#ifdef TCICT_SKIP_EXP_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   TenT result;
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
@@ -703,6 +745,9 @@ template <typename TenT> void test_exp_errors(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_inverse(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_INVERSE
+#ifdef TCICT_SKIP_INVERSE_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
   auto matrix = tci::zeros<TenT>(ctx, {2, 2});
@@ -732,6 +777,9 @@ template <typename TenT> void test_inverse(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_inverse_errors(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_INVERSE
+#ifdef TCICT_SKIP_INVERSE_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   TenT result;
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
@@ -843,6 +891,9 @@ template <typename TenT> void test_trace_partial(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_svd_basic(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_SVD
+#ifdef TCICT_SKIP_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -884,6 +935,9 @@ template <typename TenT> void test_svd_basic(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_SVD
+#ifdef TCICT_SKIP_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
 
   // [[1,2],[3,4]]
@@ -928,6 +982,9 @@ void test_svd_reconstruction(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_eigvals_diagonal(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIGVALS
+#ifdef TCICT_SKIP_EIGVALS_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -964,6 +1021,9 @@ void test_eigvals_diagonal(tci_test_fixture<TenT> &fix) {
 
 template <typename TenT> void test_eigvals_errors(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIGVALS
+#ifdef TCICT_SKIP_EIGVALS_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
   tci::cplx_ten_t<TenT> w;
@@ -979,6 +1039,9 @@ template <typename TenT> void test_eigvals_errors(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_eigvalsh_diagonal(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIGVALSH
+#ifdef TCICT_SKIP_EIGVALSH_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto eps = fix.epsilon();
 
@@ -1010,6 +1073,9 @@ void test_eigvalsh_diagonal(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 void test_eigvalsh_errors(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_EIGVALSH
+#ifdef TCICT_SKIP_EIGVALSH_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
   auto &ctx = fix.context();
   auto non_square = tci::zeros<TenT>(ctx, {2, 3});
   tci::real_ten_t<TenT> w;


### PR DESCRIPTION
## Summary

Allow backends to disable specific factorization / iterative tests **only for single-precision instantiations** (`real_t<TenT> == float`, covering both `float` and `std::complex<float>`). Closes #48.

Use case: a backend with a known buggy single-precision LAPACK `eig` can keep `test_eig_*` running for double-precision instances while opting out for single-precision, instead of disabling the API entirely (`TCICT_SKIP_EIG`) or living with red tests.

Driven by integration findings in r-ccs-cms/tensor-computing-interface-backend-cytnx (single-precision `eigh`/`eig` bugs that are difficult to fix upstream). Generalized from the originally-requested `TCICT_SKIP_EXP_SINGLE_PRECISION` to all factorization + iterative APIs uniformly per `fixture.h:54-56`.

## Changes

**`include/tcict/skip.h`** — adds `TCICT_RETURN_IF_SINGLE_PRECISION` helper and 10 documented gating flags:

```cpp
#define TCICT_RETURN_IF_SINGLE_PRECISION                                  \
  do {                                                                    \
    if constexpr (std::is_same_v<tci::real_t<TenT>, float>) {             \
      return;                                                             \
    }                                                                     \
  } while (false)
```

`if constexpr` ensures zero runtime cost for double-precision instantiations.

**`README.md`** — adds a new "Skip tests for a specific precision" subsection under the existing "Skip unimplemented functions" section, listing the 10 precision-skip flags, distinguishing the precision-skip's runtime-early-return semantics from the whole-API skip's preprocessing-time exclusion, and pointing readers to issue #50 for the planned body-discard variant.

**`include/tcict/tests/linear_algebra.h`** — 21 test-function sites get a `#ifdef TCICT_SKIP_<API>_SINGLE_PRECISION` gate inside the existing `#ifndef TCICT_SKIP_<API>` guard. Per-API breakdown:

| API | Gates |
|---|---|
| EIG | 1 | 
| EIGH | 1 |
| EIGVALS | 2 |
| EIGVALSH | 2 |
| SVD | 2 |
| TRUNC_SVD | 4 |
| QR | 1 |
| LQ | 1 |
| EXP | 5 |
| INVERSE | 2 |
| **Total** | **21** |

## Backend usage

```cpp
// At the top of the backend's test runner, before the adapter include:
#define TCICT_SKIP_EIG_SINGLE_PRECISION
#define TCICT_SKIP_EIGH_SINGLE_PRECISION
// ... add only the APIs the backend needs to skip
#include <tcict/adapters/doctest.h>
```

Or via CMake `target_compile_definitions`. Existing `TCICT_SKIP_<API>` macros are unaffected and still disable an API across all precisions.

## Semantics

- The gate is purely additive: if a backend defines none of the new macros, behavior is identical to main.
- For single-precision instances when the gate is defined, the test body returns before any assertion, so doctest sees a `TEST_CASE` with zero assertions (counted as passed). Reporting it as `SKIPPED` requires adapter-side `DOCTEST_SKIP` integration — deferred follow-up (see Inconclusive items in #48).
- The element-wise / reduction APIs (norm, scale, contract, etc.) are not gated. Precision-specific bugs in those classes are unusual; if one surfaces, that API can be added in a follow-up.

## Out of scope

- `_DOUBLE_PRECISION` symmetric variant (no current need).
- Per-test-function (rather than per-API) skip granularity.
- doctest `SKIPPED` status reporting via the adapter.
- Backend (cytnx) uptake — separate PR on the cytnx side.

## Known limitations

The skip helper is a **runtime** early return: `if constexpr (real_t<TenT> == float) return;`.
The rest of the test body is still part of the function template and gets instantiated for the matching precision.
API calls inside the body must therefore be valid for single precision at compile time.

This is sufficient for backends with **runtime-buggy** APIs (e.g., cytnx's single-precision `eig` — the call compiles, but produces wrong values).
For backends that mark a (API × precision) combination as **compile-time-unavailable** (SFINAE / `static_assert` / `= delete`), the body's API call would still fail to compile for the skipped precision; those backends should use the whole-API `TCICT_SKIP_<API>` macro instead.

A compile-time body-discard variant (`if constexpr (...) { return; } else { body }` form) is planned: see [tcict#50](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/50).
This PR documents the limitation and defers the body-discard implementation until a backend driving the need surfaces.

## Test plan

- [x] `rg -c 'TCICT_RETURN_IF_SINGLE_PRECISION' include/tcict/tests/linear_algebra.h` returns 21.
- [x] `rg -c 'TCICT_RETURN_IF_SINGLE_PRECISION' include/tcict/skip.h` returns 1 (definition).
- [x] Per-API breakdown of gate flags matches the table above.
- [x] No deletions in the diff (91 insertions, 0 deletions on `main..HEAD` after a follow-up fix that removed an erroneously-inserted gate at namespace scope inside the `trunc_svd_test_matrix` helper region; the helper is not a test function and `TenT` is not in scope there).
- [ ] Build verification: defining no new flags reproduces the existing test outcomes; defining a flag (e.g., `TCICT_SKIP_EIG_SINGLE_PRECISION`) makes single-precision instances of `test_eig_*` pass without running their assertions. Verifiable on cytnx integration.

## Risk

Minimal. Zero deletions; backends not defining the new flags see no change. Single-precision instances with a flag defined return early, which is benign in doctest (counted as passed; the existing `TCICT_SKIP_<API>` whole-API skip already produces that behavior for all precisions).


