### PR TITLE
test(trunc_svd): cover the general overload's truncation strategy

### DIFF
--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -789,16 +789,36 @@ void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<Te
                        tci::get_elem(ctx, s_simple, {coor}), tol);
   }
 
-  // The factors are compared by shape rather than elementwise: for a spectrum
-  // with distinct singular values the columns of u are fixed only up to a
-  // phase, which the two calls are not obliged to choose identically, so an
-  // elementwise comparison would assert more than the equivalence claim.
-  auto shape_u_general = tci::shape(ctx, u_general);
-  auto shape_u_simple = tci::shape(ctx, u_simple);
-  TCICT_ASSERT(shape_u_general == shape_u_simple);
-  auto shape_v_general = tci::shape(ctx, v_dag_general);
-  auto shape_v_simple = tci::shape(ctx, v_dag_simple);
-  TCICT_ASSERT(shape_v_general == shape_v_simple);
+  // The factors are compared through the product they reconstruct rather than
+  // elementwise: for a spectrum with distinct singular values the columns of u
+  // are fixed only up to a phase, which the two calls are not obliged to choose
+  // identically, so an elementwise comparison would assert more than the
+  // equivalence claim. The reconstruction is invariant under that phase, and
+  // unlike a shape comparison it does read the factors' values.
+  using RealTenT = tci::real_ten_t<TenT>;
+  auto reconstruct = [&ctx](const TenT &u_in, const RealTenT &s_in, const TenT &v_in) {
+    const auto u_shape = tci::shape(ctx, u_in);
+    auto scaled = tci::copy(ctx, u_in);
+    for (tci::bond_dim_t<TenT> j = 0; j < u_shape[1]; ++j) {
+      const auto sj = real_part<RealTenT>(
+          tci::get_elem(ctx, s_in, {static_cast<tci::elem_coor_t<RealTenT>>(j)}));
+      for (tci::bond_dim_t<TenT> i = 0; i < u_shape[0]; ++i) {
+        const auto ci = static_cast<tci::elem_coor_t<TenT>>(i);
+        const auto cj = static_cast<tci::elem_coor_t<TenT>>(j);
+        const auto elem = tci::get_elem(ctx, u_in, {ci, cj});
+        tci::set_elem(ctx, scaled, {ci, cj},
+                      make_elem<TenT>(real_part<TenT>(elem) * sj,
+                                      imag_part<TenT>(elem) * sj));
+      }
+    }
+    TenT product;
+    tci::contract(ctx, scaled, "ik", v_in, "kj", product, "ij");
+    return product;
+  };
+
+  auto reconstructed_general = reconstruct(u_general, s_general, v_dag_general);
+  auto reconstructed_simple = reconstruct(u_simple, s_simple, v_dag_simple);
+  TCICT_ASSERT(tci::close(ctx, reconstructed_general, reconstructed_simple, tol));
 #else
   (void)fix;
 #endif
@@ -839,6 +859,15 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 /// target_trunc_err at all, and reports the backend's own epsilon for that set.
 /// Feeding that value back as the target of the second call puts the tie on the
 /// boundary by construction, whatever route the backend computes epsilon by.
+///
+/// That reuse assumes the backend does not realize the one epsilon V1 names by
+/// two divergent expressions — the value it reports in trunc_err has to be the
+/// value it compares in step 3. V1 introduces epsilon once and uses that single
+/// symbol for both, so this is the specification's own reading rather than an
+/// extra requirement; but V1 constrains no arithmetic path, so an implementation
+/// that summed the discarded tail for the comparison and took the complement of
+/// the retained prefix for the report could land the two an ulp apart and fail
+/// here while conforming. A backend in that shape should compute epsilon once.
 ///
 /// SVs [5, 4, 3] give sum s_i^2 = 50 with 16 + 9 = 25 discarded at chi = 1, so
 /// the measured epsilon is 25 / 50 up to the backend's rounding. It stays well

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -463,26 +463,34 @@ TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &
 }
 
 // Helper: the spec's relative truncation error for keeping `chi` of the
-// fixture's singular values,
+// singular values in `svs`,
 //
 //   epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2.
 //
-// Evaluated here from the fixture spectrum rather than by calling back into the
-// backend, so an assertion using it compares the implementation against the
-// specification and not against a second route through the same code. Takes no
-// scale: epsilon is a ratio of sums of squares and so is scale-invariant.
-template <typename TenT> tci::real_t<TenT> trunc_svd_expected_epsilon(int chi) {
-  TCICT_ASSERT(chi >= 0 && chi <= kTruncSvdFixtureRank);
+// Evaluated here from the spectrum rather than by calling back into the backend,
+// so an assertion using it compares the implementation against the specification
+// and not against a second route through the same code. Takes no scale: epsilon
+// is a ratio of sums of squares and so is scale-invariant.
+template <typename TenT>
+tci::real_t<TenT> trunc_svd_expected_epsilon_from(const double *svs, int rank, int chi) {
+  TCICT_ASSERT(chi >= 0 && chi <= rank);
   double total = 0.0;
   double discarded = 0.0;
-  for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
-    const double s2 = kTruncSvdFixtureSvs[i] * kTruncSvdFixtureSvs[i];
+  for (int i = 0; i < rank; ++i) {
+    const double s2 = svs[i] * svs[i];
     total += s2;
     if (i >= chi) {
       discarded += s2;
     }
   }
   return static_cast<tci::real_t<TenT>>(discarded / total);
+}
+
+// Helper: the above bound to the shared [3, 2, 1, 0.1] fixture spectrum, so the
+// matrix builder and the expected values cannot drift apart.
+template <typename TenT> tci::real_t<TenT> trunc_svd_expected_epsilon(int chi) {
+  return trunc_svd_expected_epsilon_from<TenT>(kTruncSvdFixtureSvs, kTruncSvdFixtureRank,
+                                               chi);
 }
 // Helper: run overload (2) on the fixture spectrum and assert the retained chi
 // and the truncation error against the spec's epsilon for that chi.
@@ -514,8 +522,11 @@ void trunc_svd_expect_retained_chi(tci_test_fixture<TenT> &fix, double scale,
                  static_cast<tci::real_t<TenT>>(target_trunc_err),
                  static_cast<tci::real_t<TenT>>(s_min));
 
+  // bond_dim_t is unsigned on some backends, so comparing it against the int
+  // parameter warns under -Wsign-compare; the exemption the neighbouring
+  // literal comparisons rely on covers only non-negative constants.
   auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == expected_chi);
+  TCICT_ASSERT(s_shape[0] == static_cast<tci::bond_dim_t<TenT>>(expected_chi));
   TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(expected_chi), tol);
 }
 #endif
@@ -677,9 +688,8 @@ void test_trunc_svd_target_err_selects_chi(tci_test_fixture<TenT> &fix) {
 
 /// Verify the target_trunc_err decision is invariant under a uniform rescaling
 /// of the input. epsilon is a ratio of sums of squares, so scaling every
-/// singular value by 1e-3 must not move the retained chi. An implementation
-/// that compares raw singular values against target_trunc_err fails here even
-/// when it happens to agree at scale 1.
+/// singular value by 1e-3 must not move the retained chi, while a threshold
+/// applied to the raw singular values moves with the scale.
 template <typename TenT>
 void test_trunc_svd_target_err_scale_invariant(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
@@ -728,6 +738,13 @@ void test_trunc_svd_target_err_chi_max_cap(tci_test_fixture<TenT> &fix) {
 
 /// Verify overload (2) with chi_min = 1 and target_trunc_err = 0 reproduces
 /// overload (1), which V1 defines as exactly that specialization.
+///
+/// The two calls are also pinned against the spec, not only against each other.
+/// V1 lets a backend implement overload (1) by delegating to overload (2), and
+/// a backend that does so satisfies any purely differential assertion no matter
+/// what the shared route computes. Anchoring the general call's retained chi and
+/// truncation error to the values the spec prescribes for chi_max = 2 keeps the
+/// test able to fail on such a backend.
 template <typename TenT>
 void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
@@ -753,10 +770,16 @@ void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<Te
   tci::trunc_svd(ctx, matrix_simple, 1, u_simple, s_simple, v_dag_simple, err_simple,
                  static_cast<tci::bond_dim_t<TenT>>(2), static_cast<tci::real_t<TenT>>(0.0));
 
-  // Equivalence is a claim about the whole decomposition, so compare every
-  // output the two calls produce, not just the retained count.
+  // No chi below chi_max = 2 reaches epsilon <= 0, so both calls must stop at
+  // 2 and report epsilon(2). Assert that against the spec first: it is what
+  // the differential assertions below cannot supply on their own.
   auto shape_general = tci::shape(ctx, s_general);
   auto shape_simple = tci::shape(ctx, s_simple);
+  TCICT_ASSERT(shape_general[0] == static_cast<tci::bond_dim_t<TenT>>(2));
+  TCICT_ASSERT_CLOSE(err_general, trunc_svd_expected_epsilon<TenT>(2), tol);
+
+  // Equivalence is a claim about the whole decomposition, so compare every
+  // output the two calls produce, not just the retained count.
   TCICT_ASSERT(shape_general[0] == shape_simple[0]);
   TCICT_ASSERT_CLOSE(err_general, err_simple, tol);
 
@@ -800,18 +823,27 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 
 /// Verify the comparison in step 3 is `epsilon <= target_trunc_err`, not `<`.
 ///
-/// Distinguishing the two needs a target that lands exactly on an achievable
-/// epsilon. SVs [5, 4, 3] give sum s_i^2 = 50 and a discarded weight of
-/// 16 + 9 = 25 at chi = 1, so epsilon(1) = 25 / 50, a quotient of integers that
-/// is a power of two. An implementation using `<` cannot take chi = 1 and
-/// returns chi = 2 instead.
+/// Separating the two operators needs a target that lands exactly on an
+/// achievable epsilon: only there do they disagree. `<=` then retains that chi
+/// and `<` grows past it.
 ///
-/// The tie only exists if the backend reaches that quotient without rounding,
-/// which nothing in the spec obliges it to do. So the test asserts it: the
-/// returned trunc_err must equal 0.5 by exact comparison. A backend that
-/// computes epsilon through, say, a squared Frobenius norm lands a fraction of
-/// an ulp away, and that assertion says so directly instead of letting the
-/// retained-chi assertion below fail for an unexplained reason.
+/// Which bit pattern the backend's epsilon carries is not something the test may
+/// assume. The spec fixes epsilon as a formula, not an arithmetic path, so two
+/// conforming backends can land an ulp apart on the same spectrum — one summing
+/// s_i^2 directly, another dividing through a squared Frobenius norm. A target
+/// written as a literal would therefore hit the tie on the first and miss it on
+/// the second, and the miss looks exactly like a `<` implementation.
+///
+/// So the target is measured rather than written. The first call pins chi to 1
+/// through chi_max, which fixes the retained set without consulting
+/// target_trunc_err at all, and reports the backend's own epsilon for that set.
+/// Feeding that value back as the target of the second call puts the tie on the
+/// boundary by construction, whatever route the backend computes epsilon by.
+///
+/// SVs [5, 4, 3] give sum s_i^2 = 50 with 16 + 9 = 25 discarded at chi = 1, so
+/// the measured epsilon is 25 / 50 up to the backend's rounding. It stays well
+/// away from epsilon(2) = 9 / 50, so no rounding an implementation could
+/// plausibly carry lets chi = 2 satisfy the target and blur the two operators.
 template <typename TenT>
 void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
@@ -819,26 +851,47 @@ void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
   auto &ctx = fix.context();
-  auto matrix = tci::zeros<TenT>(ctx, {3, 3});
-  tci::set_elem(ctx, matrix, {0, 0}, make_elem<TenT>(5.0));
-  tci::set_elem(ctx, matrix, {1, 1}, make_elem<TenT>(4.0));
-  tci::set_elem(ctx, matrix, {2, 2}, make_elem<TenT>(3.0));
+  auto tol = tolerance(fix, tol_category::factorization);
 
+  static constexpr double kSvs[] = {5.0, 4.0, 3.0};
+  static constexpr int kRank = static_cast<int>(sizeof(kSvs) / sizeof(kSvs[0]));
+
+  auto build = [&ctx]() {
+    auto m = tci::zeros<TenT>(ctx, {kRank, kRank});
+    for (int i = 0; i < kRank; ++i) {
+      const auto coor = static_cast<tci::elem_coor_t<TenT>>(i);
+      tci::set_elem(ctx, m, {coor, coor}, make_elem<TenT>(kSvs[i]));
+    }
+    return m;
+  };
+
+  // Measure epsilon(1) with chi pinned by chi_max, so the value is read off a
+  // call that never exercises the comparison under test.
+  TenT u_pinned, v_dag_pinned;
+  tci::real_ten_t<TenT> s_pinned;
+  tci::real_t<TenT> epsilon_at_one = -1.0;
+  auto matrix_pinned = build();
+  tci::trunc_svd(ctx, matrix_pinned, 1, u_pinned, s_pinned, v_dag_pinned, epsilon_at_one,
+                 static_cast<tci::bond_dim_t<TenT>>(1), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto pinned_shape = tci::shape(ctx, s_pinned);
+  TCICT_ASSERT(pinned_shape[0] == static_cast<tci::bond_dim_t<TenT>>(1));
+  TCICT_ASSERT_CLOSE(epsilon_at_one, trunc_svd_expected_epsilon_from<TenT>(kSvs, kRank, 1),
+                     tol);
+
+  // Now let the same epsilon arrive as the target. chi = 1 is admissible under
+  // `<=` and inadmissible under `<`.
   TenT u, v_dag;
   tci::real_ten_t<TenT> s_diag;
   tci::real_t<TenT> trunc_err = -1.0;
-
+  auto matrix = build();
   tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
                  static_cast<tci::bond_dim_t<TenT>>(1),
-                 static_cast<tci::bond_dim_t<TenT>>(3),
-                 static_cast<tci::real_t<TenT>>(0.5), static_cast<tci::real_t<TenT>>(0.0));
+                 static_cast<tci::bond_dim_t<TenT>>(3), epsilon_at_one,
+                 static_cast<tci::real_t<TenT>>(0.0));
 
-  // Order matters: TCICT_ASSERT throws, so the premise has to be checked
-  // before the conclusion that rests on it. Reversed, a backend that misses the
-  // tie would fail the retained-chi assertion first and say nothing about why.
-  TCICT_ASSERT(trunc_err == static_cast<tci::real_t<TenT>>(0.5));
   auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 1);
+  TCICT_ASSERT(s_shape[0] == static_cast<tci::bond_dim_t<TenT>>(1));
 #else
   (void)fix;
 #endif

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -641,19 +641,17 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 
 // --- truncated SVD, overload (2): chi_min / chi_max / target_trunc_err / s_min ---
 //
-// V1's rule, with epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2.
-// V1 states the three clauses as an unnumbered list; they are numbered here
-// only so the paragraph below can point at them.
+// V1's rule, with epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2:
 //
-//   1. Discard all s_i < s_min.
-//   2. Among the survivors retain at least chi_min when possible; values below
-//      s_min are NOT restored to satisfy chi_min.
-//   3. Grow chi in descending order until epsilon <= target_trunc_err or
-//      chi == chi_max.
+//   - Discard all s_i < s_min.
+//   - Among the survivors retain at least chi_min when possible; values below
+//     s_min are NOT restored to satisfy chi_min.
+//   - Grow chi in descending order until epsilon <= target_trunc_err or
+//     chi == chi_max.
 //
-// Step 2 is what keeps the retained chi from being simply "the smallest chi in
-// [chi_min, chi_max] meeting the target": when fewer than chi_min values
-// survive step 1, the result is below chi_min.
+// That middle clause is what keeps the retained chi from being simply "the
+// smallest chi in [chi_min, chi_max] meeting the target": when fewer than
+// chi_min values clear s_min, the result is below chi_min.
 //
 // For the [3, 2, 1, 0.1] fixture, sum s_i^2 = 14.01 and the ladder runs
 // epsilon(4) = 0, epsilon(3) = 0.01/14.01 ≈ 7.138e-4,

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -449,9 +449,11 @@ inline constexpr int kTruncSvdFixtureRank =
 template <typename TenT>
 TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx,
                            double scale = 1.0) {
-  // bond_dim_t / elem_coor_t are backend-defined and may be unsigned, so the
-  // loop counter cannot be spelled `int` — a narrowing conversion inside a
-  // braced initializer is ill-formed for a non-constant expression.
+  // bond_dim_t / elem_coor_t are backend-defined and may be unsigned. A braced
+  // initializer rejects a narrowing conversion unless the argument is a
+  // constant expression, so the loop counter has to be converted before it is
+  // placed in one — which is why the casts below are not redundant even though
+  // the literal-indexed form this replaced needed none.
   const auto rank = static_cast<tci::bond_dim_t<TenT>>(kTruncSvdFixtureRank);
   auto matrix = tci::zeros<TenT>(ctx, {rank, rank});
   for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
@@ -472,6 +474,7 @@ TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &
 // specification and not against a second route through the same code. Takes no
 // scale: epsilon is a ratio of sums of squares and so is scale-invariant.
 template <typename TenT> tci::real_t<TenT> trunc_svd_expected_epsilon(int chi) {
+  TCICT_ASSERT(chi >= 0 && chi <= kTruncSvdFixtureRank);
   double total = 0.0;
   double discarded = 0.0;
   for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
@@ -614,11 +617,46 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 // quotients round; the one test that does need an exact quotient chooses a
 // different spectrum and asserts the exactness it needs.
 //
-// These tests read the retained chi as shape(s_diag)[0] and deliberately assert
-// nothing about s_diag's order. V1 defines it (as sigma) to be a second-order
-// {chi, chi} diagonal tensor while the suite elsewhere still asserts the
-// first-order representation; shape[0] is the retained chi under either, so
-// these tests do not need revisiting when that representation is migrated.
+// These tests read the retained chi as shape(s_diag)[0], which is the retained
+// chi whether s_diag is first-order or the second-order {chi, chi} diagonal
+// tensor V1 defines (as sigma), so that read survives the representation
+// migration the suite has not made yet.
+//
+// One exception, called out because the rest of the block would otherwise imply
+// it does not exist: test_trunc_svd_target_err_zero_matches_chi_max_overload
+// compares singular values elementwise with a single coordinate, which is only
+// valid while s_diag is first-order. That read has to move when sigma does.
+
+// Helper: run overload (2) on the fixture spectrum and assert the retained chi
+// and the truncation error against the spec's epsilon for that chi.
+//
+// Five of the tests below differ only in the four strategy arguments, the
+// fixture scale, and the expected chi, so the call and its two assertions live
+// here once. They stay separate test functions: the registration macro expands
+// one consumer test case per function, and merging them would collapse the
+// per-case reporting and skip granularity that buys.
+template <typename TenT>
+void trunc_svd_expect_retained_chi(tci_test_fixture<TenT> &fix, double scale,
+                                   int chi_min, int chi_max, double target_trunc_err,
+                                   double s_min, int expected_chi) {
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx, scale);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(chi_min),
+                 static_cast<tci::bond_dim_t<TenT>>(chi_max),
+                 static_cast<tci::real_t<TenT>>(target_trunc_err),
+                 static_cast<tci::real_t<TenT>>(s_min));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == expected_chi);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(expected_chi), tol);
+}
 
 /// Verify target_trunc_err selects an interior chi via the epsilon ladder.
 /// epsilon(2) ≈ 0.07209 <= 0.1 < epsilon(1) ≈ 0.3576, so chi must be 2.
@@ -628,22 +666,9 @@ void test_trunc_svd_target_err_selects_chi(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
-  auto &ctx = fix.context();
-  auto tol = tolerance(fix, tol_category::factorization);
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(1),
-                 static_cast<tci::bond_dim_t<TenT>>(4),
-                 static_cast<tci::real_t<TenT>>(0.1), static_cast<tci::real_t<TenT>>(0.0));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 2);
-  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
+  trunc_svd_expect_retained_chi<TenT>(fix, /*scale=*/1.0, /*chi_min=*/1, /*chi_max=*/4,
+                                     /*target_trunc_err=*/0.1, /*s_min=*/0.0,
+                                     /*expected_chi=*/2);
 #else
   (void)fix;
 #endif
@@ -660,22 +685,9 @@ void test_trunc_svd_target_err_scale_invariant(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
-  auto &ctx = fix.context();
-  auto tol = tolerance(fix, tol_category::factorization);
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx, 1.0e-3);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(1),
-                 static_cast<tci::bond_dim_t<TenT>>(4),
-                 static_cast<tci::real_t<TenT>>(0.1), static_cast<tci::real_t<TenT>>(0.0));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 2);
-  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
+  trunc_svd_expect_retained_chi<TenT>(fix, /*scale=*/1.0e-3, /*chi_min=*/1, /*chi_max=*/4,
+                                     /*target_trunc_err=*/0.1, /*s_min=*/0.0,
+                                     /*expected_chi=*/2);
 #else
   (void)fix;
 #endif
@@ -689,22 +701,9 @@ void test_trunc_svd_target_err_chi_min_floor(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
-  auto &ctx = fix.context();
-  auto tol = tolerance(fix, tol_category::factorization);
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(3),
-                 static_cast<tci::bond_dim_t<TenT>>(4),
-                 static_cast<tci::real_t<TenT>>(0.5), static_cast<tci::real_t<TenT>>(0.0));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 3);
-  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(3), tol);
+  trunc_svd_expect_retained_chi<TenT>(fix, /*scale=*/1.0, /*chi_min=*/3, /*chi_max=*/4,
+                                     /*target_trunc_err=*/0.5, /*s_min=*/0.0,
+                                     /*expected_chi=*/3);
 #else
   (void)fix;
 #endif
@@ -718,22 +717,9 @@ void test_trunc_svd_target_err_chi_max_cap(tci_test_fixture<TenT> &fix) {
 #ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
-  auto &ctx = fix.context();
-  auto tol = tolerance(fix, tol_category::factorization);
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(1),
-                 static_cast<tci::bond_dim_t<TenT>>(2),
-                 static_cast<tci::real_t<TenT>>(1.0e-6), static_cast<tci::real_t<TenT>>(0.0));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 2);
-  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
+  trunc_svd_expect_retained_chi<TenT>(fix, /*scale=*/1.0, /*chi_min=*/1, /*chi_max=*/2,
+                                     /*target_trunc_err=*/1.0e-6, /*s_min=*/0.0,
+                                     /*expected_chi=*/2);
 #else
   (void)fix;
 #endif
@@ -779,6 +765,10 @@ void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<Te
                        tci::get_elem(ctx, s_simple, {coor}), tol);
   }
 
+  // The factors are compared by shape rather than elementwise: for a spectrum
+  // with distinct singular values the columns of u are fixed only up to a
+  // phase, which the two calls are not obliged to choose identically, so an
+  // elementwise comparison would assert more than the equivalence claim.
   auto shape_u_general = tci::shape(ctx, u_general);
   auto shape_u_simple = tci::shape(ctx, u_simple);
   TCICT_ASSERT(shape_u_general == shape_u_simple);
@@ -853,9 +843,12 @@ void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix
                  static_cast<tci::bond_dim_t<TenT>>(3),
                  static_cast<tci::real_t<TenT>>(0.5), static_cast<tci::real_t<TenT>>(0.0));
 
+  // Order matters: TCICT_ASSERT throws, so the premise has to be checked
+  // before the conclusion that rests on it. Reversed, a backend that misses the
+  // tie would fail the retained-chi assertion first and say nothing about why.
+  TCICT_ASSERT(trunc_err == static_cast<tci::real_t<TenT>>(0.5));
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 1);
-  TCICT_ASSERT(trunc_err == static_cast<tci::real_t<TenT>>(0.5));
 #else
   (void)fix;
 #endif

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -429,16 +429,23 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 // --- truncated SVD ---
 
 #ifndef TCICT_SKIP_TRUNC_SVD
-// Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1].
+// Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1] * scale.
 // Only defined when TRUNC_SVD tests are active so partial backends without
 // tci::zeros / tci::set_elem do not need to declare them.
+//
+// `scale` multiplies every singular value uniformly. The relative truncation
+// error epsilon is a ratio of sums of squares, so it is invariant under that
+// scaling; a test can therefore vary `scale` to separate an implementation
+// that thresholds on epsilon from one that thresholds on the raw singular
+// values.
 template <typename TenT>
-TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx) {
+TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx,
+                           double scale = 1.0) {
   auto matrix = tci::zeros<TenT>(ctx, {4, 4});
-  tci::set_elem(ctx, matrix, {0, 0}, make_elem<TenT>(3.0));
-  tci::set_elem(ctx, matrix, {1, 1}, make_elem<TenT>(2.0));
-  tci::set_elem(ctx, matrix, {2, 2}, make_elem<TenT>(1.0));
-  tci::set_elem(ctx, matrix, {3, 3}, make_elem<TenT>(0.1));
+  tci::set_elem(ctx, matrix, {0, 0}, make_elem<TenT>(3.0 * scale));
+  tci::set_elem(ctx, matrix, {1, 1}, make_elem<TenT>(2.0 * scale));
+  tci::set_elem(ctx, matrix, {2, 2}, make_elem<TenT>(1.0 * scale));
+  tci::set_elem(ctx, matrix, {3, 3}, make_elem<TenT>(0.1 * scale));
   return matrix;
 }
 #endif
@@ -552,6 +559,255 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
   tci::real_t<TenT> expected =
       (2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
   TCICT_ASSERT_CLOSE(trunc_err, expected, eps);
+#else
+  (void)fix;
+#endif
+}
+
+// --- truncated SVD, overload (2): chi_min / chi_max / target_trunc_err / s_min ---
+//
+// V1 defines the retained chi as the smallest chi in [chi_min, chi_max] whose
+// epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2 satisfies
+// epsilon <= target_trunc_err, falling back to chi_max when none qualifies:
+//
+//   1. Discard all s_i < s_min.
+//   2. Among the survivors retain at least chi_min when possible; values below
+//      s_min are NOT restored to satisfy chi_min.
+//   3. Grow chi in descending order until epsilon <= target_trunc_err or
+//      chi == chi_max.
+//
+// For the [3, 2, 1, 0.1] fixture, sum s_i^2 = 14.01 and the epsilon ladder is
+// exact: epsilon(4) = 0, epsilon(3) = 0.01/14.01 ≈ 7.138e-4,
+// epsilon(2) = 1.01/14.01 ≈ 0.07209, epsilon(1) = 5.01/14.01 ≈ 0.3576.
+//
+// These tests read the retained chi as shape(sigma)[0] and deliberately assert
+// nothing about sigma's order. V1 defines sigma as a second-order {chi, chi}
+// diagonal tensor while the suite elsewhere still asserts the first-order
+// representation; shape[0] is the retained chi under either, so these tests do
+// not need revisiting when that representation is migrated.
+
+/// Verify target_trunc_err selects an interior chi via the epsilon ladder.
+/// epsilon(2) ≈ 0.07209 <= 0.1 < epsilon(1) ≈ 0.3576, so chi must be 2.
+template <typename TenT>
+void test_trunc_svd_target_err_selects_chi(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(1),
+                 static_cast<tci::bond_dim_t<TenT>>(4),
+                 static_cast<tci::real_t<TenT>>(0.1), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 2);
+  tci::real_t<TenT> expected =
+      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
+  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify the target_trunc_err decision is invariant under a uniform rescaling
+/// of the input. epsilon is a ratio of sums of squares, so scaling every
+/// singular value by 1e-3 must not move the retained chi. An implementation
+/// that compares raw singular values against target_trunc_err fails here even
+/// when it happens to agree at scale 1.
+template <typename TenT>
+void test_trunc_svd_target_err_scale_invariant(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx, 1.0e-3);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(1),
+                 static_cast<tci::bond_dim_t<TenT>>(4),
+                 static_cast<tci::real_t<TenT>>(0.1), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 2);
+  tci::real_t<TenT> expected =
+      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
+  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify chi_min floors the selection. epsilon(1) ≈ 0.3576 <= 0.5 would allow
+/// chi = 1, but chi_min = 3 forbids it.
+template <typename TenT>
+void test_trunc_svd_target_err_chi_min_floor(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(3),
+                 static_cast<tci::bond_dim_t<TenT>>(4),
+                 static_cast<tci::real_t<TenT>>(0.5), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 3);
+  tci::real_t<TenT> expected =
+      (0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
+  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify chi_max caps the selection. No chi <= 2 reaches epsilon <= 1e-6, so
+/// the growth stops at chi_max rather than continuing to satisfy the target.
+template <typename TenT>
+void test_trunc_svd_target_err_chi_max_cap(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(1),
+                 static_cast<tci::bond_dim_t<TenT>>(2),
+                 static_cast<tci::real_t<TenT>>(1.0e-6), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 2);
+  tci::real_t<TenT> expected =
+      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
+  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify overload (2) with chi_min = 1 and target_trunc_err = 0 reproduces
+/// overload (1), which V1 defines as exactly that specialization.
+template <typename TenT>
+void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+
+  TenT u_general, v_dag_general;
+  tci::real_ten_t<TenT> s_general;
+  tci::real_t<TenT> err_general = -1.0;
+  auto matrix_general = trunc_svd_test_matrix<TenT>(ctx);
+  tci::trunc_svd(ctx, matrix_general, 1, u_general, s_general, v_dag_general, err_general,
+                 static_cast<tci::bond_dim_t<TenT>>(1),
+                 static_cast<tci::bond_dim_t<TenT>>(2),
+                 static_cast<tci::real_t<TenT>>(0.0), static_cast<tci::real_t<TenT>>(0.0));
+
+  TenT u_simple, v_dag_simple;
+  tci::real_ten_t<TenT> s_simple;
+  tci::real_t<TenT> err_simple = -1.0;
+  auto matrix_simple = trunc_svd_test_matrix<TenT>(ctx);
+  tci::trunc_svd(ctx, matrix_simple, 1, u_simple, s_simple, v_dag_simple, err_simple,
+                 static_cast<tci::bond_dim_t<TenT>>(2), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto shape_general = tci::shape(ctx, s_general);
+  auto shape_simple = tci::shape(ctx, s_simple);
+  TCICT_ASSERT(shape_general[0] == shape_simple[0]);
+  TCICT_ASSERT_CLOSE(err_general, err_simple, tol);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify step 2's exclusion: singular values discarded by s_min are not
+/// restored to satisfy chi_min. s_min = 0.5 leaves survivors [3, 2, 1], and
+/// chi_min = 4 cannot be met, so chi must be 3 rather than 4.
+template <typename TenT>
+void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(4),
+                 static_cast<tci::bond_dim_t<TenT>>(4),
+                 static_cast<tci::real_t<TenT>>(0.0), static_cast<tci::real_t<TenT>>(0.5));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 3);
+#else
+  (void)fix;
+#endif
+}
+
+/// Verify the comparison in step 3 is `epsilon <= target_trunc_err`, not `<`.
+///
+/// Fixture SVs [5, 4, 3] give sum s_i^2 = 50 and, for chi = 1, a discarded
+/// weight of 16 + 9 = 25, so epsilon(1) = 25 / 50 = 0.5 — a tie with the target
+/// below, and one that is exact in binary floating point at every step: the
+/// singular values, their squares, and both sums are integers, and the quotient
+/// is a power of two. An implementation using `<` cannot take chi = 1 and
+/// returns chi = 2 instead.
+template <typename TenT>
+void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix) {
+#ifndef TCICT_SKIP_TRUNC_SVD
+#ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
+  TCICT_RETURN_IF_SINGLE_PRECISION;
+#endif
+  auto &ctx = fix.context();
+  auto matrix = tci::zeros<TenT>(ctx, {3, 3});
+  tci::set_elem(ctx, matrix, {0, 0}, make_elem<TenT>(5.0));
+  tci::set_elem(ctx, matrix, {1, 1}, make_elem<TenT>(4.0));
+  tci::set_elem(ctx, matrix, {2, 2}, make_elem<TenT>(3.0));
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(1),
+                 static_cast<tci::bond_dim_t<TenT>>(3),
+                 static_cast<tci::real_t<TenT>>(0.5), static_cast<tci::real_t<TenT>>(0.0));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == 1);
 #else
   (void)fix;
 #endif
@@ -1106,6 +1362,13 @@ void test_eigvalsh_errors(tci_test_fixture<TenT> &fix) {
   X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_value) \
   X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_no_truncation) \
   X(__VA_ARGS__, "linear_algebra", test_trunc_svd_trunc_err_bounded) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_selects_chi) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_scale_invariant) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_chi_min_floor) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_chi_max_cap) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_zero_matches_chi_max_overload) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_chi_min_not_restored_below_s_min) \
+  X(__VA_ARGS__, "linear_algebra", test_trunc_svd_target_err_boundary_is_inclusive) \
   X(__VA_ARGS__, "linear_algebra", test_eig_identity) \
   X(__VA_ARGS__, "linear_algebra", test_eigh_identity) \
   X(__VA_ARGS__, "linear_algebra", test_exp_identity) \

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -451,8 +451,8 @@ TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &
                            double scale = 1.0) {
   // elem_coor_t is backend-defined and may be unsigned, and a braced
   // initializer rejects a narrowing conversion unless the argument is a
-  // constant expression. kTruncSvdFixtureRank is one, so the shape needs no
-  // cast; the loop counter is not, so the coordinates below do.
+  // constant expression. kTruncSvdFixtureRank is a constant expression, so the
+  // shape below needs no cast; the loop counter is not, so the coordinates do.
   auto matrix = tci::zeros<TenT>(ctx, {kTruncSvdFixtureRank, kTruncSvdFixtureRank});
   for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
     const auto coor = static_cast<tci::elem_coor_t<TenT>>(i);
@@ -641,7 +641,9 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 
 // --- truncated SVD, overload (2): chi_min / chi_max / target_trunc_err / s_min ---
 //
-// V1's rule, with epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2:
+// V1's rule, with epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2.
+// V1 states the three clauses as an unnumbered list; they are numbered here
+// only so the paragraph below can point at them.
 //
 //   1. Discard all s_i < s_min.
 //   2. Among the survivors retain at least chi_min when possible; values below
@@ -824,9 +826,9 @@ void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<Te
 #endif
 }
 
-/// Verify step 2's exclusion: singular values discarded by s_min are not
-/// restored to satisfy chi_min. s_min = 0.5 leaves survivors [3, 2, 1], and
-/// chi_min = 4 cannot be met, so chi must be 3 rather than 4.
+/// Verify that singular values discarded by s_min are not restored to satisfy
+/// chi_min. s_min = 0.5 leaves survivors [3, 2, 1], and chi_min = 4 cannot be
+/// met, so chi must be 3 rather than 4.
 template <typename TenT>
 void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
@@ -841,7 +843,8 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 #endif
 }
 
-/// Verify the comparison in step 3 is `epsilon <= target_trunc_err`, not `<`.
+/// Verify that chi stops growing as soon as epsilon reaches target_trunc_err:
+/// the comparison bounding the growth is `<=`, not `<`.
 ///
 /// Separating the two operators needs a target that lands exactly on an
 /// achievable epsilon: only there do they disagree. `<=` then retains that chi
@@ -862,7 +865,7 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 ///
 /// That reuse assumes the backend does not realize the one epsilon V1 names by
 /// two divergent expressions — the value it reports in trunc_err has to be the
-/// value it compares in step 3. V1 introduces epsilon once and uses that single
+/// value it compares against target_trunc_err. V1 introduces epsilon once and uses that single
 /// symbol for both, so this is the specification's own reading rather than an
 /// extra requirement; but V1 constrains no arithmetic path, so an implementation
 /// that summed the discarded tail for the comparison and took the complement of

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -449,13 +449,11 @@ inline constexpr int kTruncSvdFixtureRank =
 template <typename TenT>
 TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx,
                            double scale = 1.0) {
-  // bond_dim_t / elem_coor_t are backend-defined and may be unsigned. A braced
+  // elem_coor_t is backend-defined and may be unsigned, and a braced
   // initializer rejects a narrowing conversion unless the argument is a
-  // constant expression, so the loop counter has to be converted before it is
-  // placed in one — which is why the casts below are not redundant even though
-  // the literal-indexed form this replaced needed none.
-  const auto rank = static_cast<tci::bond_dim_t<TenT>>(kTruncSvdFixtureRank);
-  auto matrix = tci::zeros<TenT>(ctx, {rank, rank});
+  // constant expression. kTruncSvdFixtureRank is one, so the shape needs no
+  // cast; the loop counter is not, so the coordinates below do.
+  auto matrix = tci::zeros<TenT>(ctx, {kTruncSvdFixtureRank, kTruncSvdFixtureRank});
   for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
     const auto coor = static_cast<tci::elem_coor_t<TenT>>(i);
     tci::set_elem(ctx, matrix, {coor, coor},
@@ -485,6 +483,40 @@ template <typename TenT> tci::real_t<TenT> trunc_svd_expected_epsilon(int chi) {
     }
   }
   return static_cast<tci::real_t<TenT>>(discarded / total);
+}
+// Helper: run overload (2) on the fixture spectrum and assert the retained chi
+// and the truncation error against the spec's epsilon for that chi.
+//
+// The strategy tests below differ only in the four strategy arguments, the
+// fixture scale, and the expected chi, so the call and its two assertions live
+// here once. They stay separate test functions: the registration macro expands
+// one consumer test case per function, and merging them would collapse the
+// per-case reporting and skip granularity that buys.
+//
+// Guarded with the tests it serves, and for the same reason the fixture builder
+// above is: it calls both of them, so leaving it outside would break the header
+// for a backend that defines TCICT_SKIP_TRUNC_SVD.
+template <typename TenT>
+void trunc_svd_expect_retained_chi(tci_test_fixture<TenT> &fix, double scale,
+                                   int chi_min, int chi_max, double target_trunc_err,
+                                   double s_min, int expected_chi) {
+  auto &ctx = fix.context();
+  auto tol = tolerance(fix, tol_category::factorization);
+  auto matrix = trunc_svd_test_matrix<TenT>(ctx, scale);
+
+  TenT u, v_dag;
+  tci::real_ten_t<TenT> s_diag;
+  tci::real_t<TenT> trunc_err = -1.0;
+
+  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
+                 static_cast<tci::bond_dim_t<TenT>>(chi_min),
+                 static_cast<tci::bond_dim_t<TenT>>(chi_max),
+                 static_cast<tci::real_t<TenT>>(target_trunc_err),
+                 static_cast<tci::real_t<TenT>>(s_min));
+
+  auto s_shape = tci::shape(ctx, s_diag);
+  TCICT_ASSERT(s_shape[0] == expected_chi);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(expected_chi), tol);
 }
 #endif
 
@@ -627,37 +659,6 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 // compares singular values elementwise with a single coordinate, which is only
 // valid while s_diag is first-order. That read has to move when sigma does.
 
-// Helper: run overload (2) on the fixture spectrum and assert the retained chi
-// and the truncation error against the spec's epsilon for that chi.
-//
-// Five of the tests below differ only in the four strategy arguments, the
-// fixture scale, and the expected chi, so the call and its two assertions live
-// here once. They stay separate test functions: the registration macro expands
-// one consumer test case per function, and merging them would collapse the
-// per-case reporting and skip granularity that buys.
-template <typename TenT>
-void trunc_svd_expect_retained_chi(tci_test_fixture<TenT> &fix, double scale,
-                                   int chi_min, int chi_max, double target_trunc_err,
-                                   double s_min, int expected_chi) {
-  auto &ctx = fix.context();
-  auto tol = tolerance(fix, tol_category::factorization);
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx, scale);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(chi_min),
-                 static_cast<tci::bond_dim_t<TenT>>(chi_max),
-                 static_cast<tci::real_t<TenT>>(target_trunc_err),
-                 static_cast<tci::real_t<TenT>>(s_min));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == expected_chi);
-  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(expected_chi), tol);
-}
-
 /// Verify target_trunc_err selects an interior chi via the epsilon ladder.
 /// epsilon(2) ≈ 0.07209 <= 0.1 < epsilon(1) ≈ 0.3576, so chi must be 2.
 template <typename TenT>
@@ -789,20 +790,9 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 #ifdef TCICT_SKIP_TRUNC_SVD_SINGLE_PRECISION
   TCICT_RETURN_IF_SINGLE_PRECISION;
 #endif
-  auto &ctx = fix.context();
-  auto matrix = trunc_svd_test_matrix<TenT>(ctx);
-
-  TenT u, v_dag;
-  tci::real_ten_t<TenT> s_diag;
-  tci::real_t<TenT> trunc_err = -1.0;
-
-  tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
-                 static_cast<tci::bond_dim_t<TenT>>(4),
-                 static_cast<tci::bond_dim_t<TenT>>(4),
-                 static_cast<tci::real_t<TenT>>(0.0), static_cast<tci::real_t<TenT>>(0.5));
-
-  auto s_shape = tci::shape(ctx, s_diag);
-  TCICT_ASSERT(s_shape[0] == 3);
+  trunc_svd_expect_retained_chi<TenT>(fix, /*scale=*/1.0, /*chi_min=*/4, /*chi_max=*/4,
+                                     /*target_trunc_err=*/0.0, /*s_min=*/0.5,
+                                     /*expected_chi=*/3);
 #else
   (void)fix;
 #endif

--- a/include/tcict/tests/linear_algebra.h
+++ b/include/tcict/tests/linear_algebra.h
@@ -429,7 +429,15 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 // --- truncated SVD ---
 
 #ifndef TCICT_SKIP_TRUNC_SVD
-// Helper: build 4×4 diagonal matrix with SVs [3, 2, 1, 0.1] * scale.
+// The singular values the trunc_svd fixture matrix is built from. Shared with
+// trunc_svd_expected_epsilon below so the matrix and the expected values cannot
+// drift apart.
+inline constexpr double kTruncSvdFixtureSvs[] = {3.0, 2.0, 1.0, 0.1};
+inline constexpr int kTruncSvdFixtureRank =
+    static_cast<int>(sizeof(kTruncSvdFixtureSvs) / sizeof(kTruncSvdFixtureSvs[0]));
+
+// Helper: build a diagonal matrix whose singular values are the fixture
+// spectrum scaled by `scale`.
 // Only defined when TRUNC_SVD tests are active so partial backends without
 // tci::zeros / tci::set_elem do not need to declare them.
 //
@@ -441,12 +449,39 @@ template <typename TenT> void test_lq(tci_test_fixture<TenT> &fix) {
 template <typename TenT>
 TenT trunc_svd_test_matrix(typename tci::tensor_traits<TenT>::context_handle_t &ctx,
                            double scale = 1.0) {
-  auto matrix = tci::zeros<TenT>(ctx, {4, 4});
-  tci::set_elem(ctx, matrix, {0, 0}, make_elem<TenT>(3.0 * scale));
-  tci::set_elem(ctx, matrix, {1, 1}, make_elem<TenT>(2.0 * scale));
-  tci::set_elem(ctx, matrix, {2, 2}, make_elem<TenT>(1.0 * scale));
-  tci::set_elem(ctx, matrix, {3, 3}, make_elem<TenT>(0.1 * scale));
+  // bond_dim_t / elem_coor_t are backend-defined and may be unsigned, so the
+  // loop counter cannot be spelled `int` — a narrowing conversion inside a
+  // braced initializer is ill-formed for a non-constant expression.
+  const auto rank = static_cast<tci::bond_dim_t<TenT>>(kTruncSvdFixtureRank);
+  auto matrix = tci::zeros<TenT>(ctx, {rank, rank});
+  for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
+    const auto coor = static_cast<tci::elem_coor_t<TenT>>(i);
+    tci::set_elem(ctx, matrix, {coor, coor},
+                  make_elem<TenT>(kTruncSvdFixtureSvs[i] * scale));
+  }
   return matrix;
+}
+
+// Helper: the spec's relative truncation error for keeping `chi` of the
+// fixture's singular values,
+//
+//   epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2.
+//
+// Evaluated here from the fixture spectrum rather than by calling back into the
+// backend, so an assertion using it compares the implementation against the
+// specification and not against a second route through the same code. Takes no
+// scale: epsilon is a ratio of sums of squares and so is scale-invariant.
+template <typename TenT> tci::real_t<TenT> trunc_svd_expected_epsilon(int chi) {
+  double total = 0.0;
+  double discarded = 0.0;
+  for (int i = 0; i < kTruncSvdFixtureRank; ++i) {
+    const double s2 = kTruncSvdFixtureSvs[i] * kTruncSvdFixtureSvs[i];
+    total += s2;
+    if (i >= chi) {
+      discarded += s2;
+    }
+  }
+  return static_cast<tci::real_t<TenT>>(discarded / total);
 }
 #endif
 
@@ -496,10 +531,7 @@ void test_trunc_svd_trunc_err_value(tci_test_fixture<TenT> &fix) {
   tci::trunc_svd(ctx, matrix, 1, u, s_diag, v_dag, trunc_err,
                  static_cast<tci::bond_dim_t<TenT>>(2), 0.0);
 
-  // Expected: sum(discarded^2) / sum(all^2) = (1 + 0.01) / (9 + 4 + 1 + 0.01)
-  tci::real_t<TenT> expected =
-      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, eps);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), eps);
 #else
   (void)fix;
 #endif
@@ -555,10 +587,7 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
   TCICT_ASSERT(trunc_err >= 0.0);
   TCICT_ASSERT(trunc_err <= 1.0);
 
-  // Expected: (4 + 1 + 0.01) / (9 + 4 + 1 + 0.01) = 5.01 / 14.01 ≈ 0.3576
-  tci::real_t<TenT> expected =
-      (2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, eps);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(1), eps);
 #else
   (void)fix;
 #endif
@@ -566,9 +595,7 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 
 // --- truncated SVD, overload (2): chi_min / chi_max / target_trunc_err / s_min ---
 //
-// V1 defines the retained chi as the smallest chi in [chi_min, chi_max] whose
-// epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2 satisfies
-// epsilon <= target_trunc_err, falling back to chi_max when none qualifies:
+// V1's rule, with epsilon(chi) = sum_{i>=chi} s_i^2 / sum_{i<kappa} s_i^2:
 //
 //   1. Discard all s_i < s_min.
 //   2. Among the survivors retain at least chi_min when possible; values below
@@ -576,15 +603,22 @@ void test_trunc_svd_trunc_err_bounded(tci_test_fixture<TenT> &fix) {
 //   3. Grow chi in descending order until epsilon <= target_trunc_err or
 //      chi == chi_max.
 //
-// For the [3, 2, 1, 0.1] fixture, sum s_i^2 = 14.01 and the epsilon ladder is
-// exact: epsilon(4) = 0, epsilon(3) = 0.01/14.01 ≈ 7.138e-4,
-// epsilon(2) = 1.01/14.01 ≈ 0.07209, epsilon(1) = 5.01/14.01 ≈ 0.3576.
+// Step 2 is what keeps the retained chi from being simply "the smallest chi in
+// [chi_min, chi_max] meeting the target": when fewer than chi_min values
+// survive step 1, the result is below chi_min.
 //
-// These tests read the retained chi as shape(sigma)[0] and deliberately assert
-// nothing about sigma's order. V1 defines sigma as a second-order {chi, chi}
-// diagonal tensor while the suite elsewhere still asserts the first-order
-// representation; shape[0] is the retained chi under either, so these tests do
-// not need revisiting when that representation is migrated.
+// For the [3, 2, 1, 0.1] fixture, sum s_i^2 = 14.01 and the ladder runs
+// epsilon(4) = 0, epsilon(3) = 0.01/14.01 ≈ 7.138e-4,
+// epsilon(2) = 1.01/14.01 ≈ 0.07209, epsilon(1) = 5.01/14.01 ≈ 0.3576. The
+// targets below sit well clear of these, so the tests do not depend on how the
+// quotients round; the one test that does need an exact quotient chooses a
+// different spectrum and asserts the exactness it needs.
+//
+// These tests read the retained chi as shape(s_diag)[0] and deliberately assert
+// nothing about s_diag's order. V1 defines it (as sigma) to be a second-order
+// {chi, chi} diagonal tensor while the suite elsewhere still asserts the
+// first-order representation; shape[0] is the retained chi under either, so
+// these tests do not need revisiting when that representation is migrated.
 
 /// Verify target_trunc_err selects an interior chi via the epsilon ladder.
 /// epsilon(2) ≈ 0.07209 <= 0.1 < epsilon(1) ≈ 0.3576, so chi must be 2.
@@ -609,9 +643,7 @@ void test_trunc_svd_target_err_selects_chi(tci_test_fixture<TenT> &fix) {
 
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 2);
-  tci::real_t<TenT> expected =
-      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
 #else
   (void)fix;
 #endif
@@ -643,9 +675,7 @@ void test_trunc_svd_target_err_scale_invariant(tci_test_fixture<TenT> &fix) {
 
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 2);
-  tci::real_t<TenT> expected =
-      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
 #else
   (void)fix;
 #endif
@@ -674,9 +704,7 @@ void test_trunc_svd_target_err_chi_min_floor(tci_test_fixture<TenT> &fix) {
 
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 3);
-  tci::real_t<TenT> expected =
-      (0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(3), tol);
 #else
   (void)fix;
 #endif
@@ -705,9 +733,7 @@ void test_trunc_svd_target_err_chi_max_cap(tci_test_fixture<TenT> &fix) {
 
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 2);
-  tci::real_t<TenT> expected =
-      (1.0 * 1.0 + 0.1 * 0.1) / (3.0 * 3.0 + 2.0 * 2.0 + 1.0 * 1.0 + 0.1 * 0.1);
-  TCICT_ASSERT_CLOSE(trunc_err, expected, tol);
+  TCICT_ASSERT_CLOSE(trunc_err, trunc_svd_expected_epsilon<TenT>(2), tol);
 #else
   (void)fix;
 #endif
@@ -740,10 +766,25 @@ void test_trunc_svd_target_err_zero_matches_chi_max_overload(tci_test_fixture<Te
   tci::trunc_svd(ctx, matrix_simple, 1, u_simple, s_simple, v_dag_simple, err_simple,
                  static_cast<tci::bond_dim_t<TenT>>(2), static_cast<tci::real_t<TenT>>(0.0));
 
+  // Equivalence is a claim about the whole decomposition, so compare every
+  // output the two calls produce, not just the retained count.
   auto shape_general = tci::shape(ctx, s_general);
   auto shape_simple = tci::shape(ctx, s_simple);
   TCICT_ASSERT(shape_general[0] == shape_simple[0]);
   TCICT_ASSERT_CLOSE(err_general, err_simple, tol);
+
+  for (tci::bond_dim_t<TenT> i = 0; i < shape_general[0]; ++i) {
+    const auto coor = static_cast<tci::elem_coor_t<tci::real_ten_t<TenT>>>(i);
+    TCICT_ASSERT_CLOSE(tci::get_elem(ctx, s_general, {coor}),
+                       tci::get_elem(ctx, s_simple, {coor}), tol);
+  }
+
+  auto shape_u_general = tci::shape(ctx, u_general);
+  auto shape_u_simple = tci::shape(ctx, u_simple);
+  TCICT_ASSERT(shape_u_general == shape_u_simple);
+  auto shape_v_general = tci::shape(ctx, v_dag_general);
+  auto shape_v_simple = tci::shape(ctx, v_dag_simple);
+  TCICT_ASSERT(shape_v_general == shape_v_simple);
 #else
   (void)fix;
 #endif
@@ -779,12 +820,18 @@ void test_trunc_svd_chi_min_not_restored_below_s_min(tci_test_fixture<TenT> &fix
 
 /// Verify the comparison in step 3 is `epsilon <= target_trunc_err`, not `<`.
 ///
-/// Fixture SVs [5, 4, 3] give sum s_i^2 = 50 and, for chi = 1, a discarded
-/// weight of 16 + 9 = 25, so epsilon(1) = 25 / 50 = 0.5 — a tie with the target
-/// below, and one that is exact in binary floating point at every step: the
-/// singular values, their squares, and both sums are integers, and the quotient
+/// Distinguishing the two needs a target that lands exactly on an achievable
+/// epsilon. SVs [5, 4, 3] give sum s_i^2 = 50 and a discarded weight of
+/// 16 + 9 = 25 at chi = 1, so epsilon(1) = 25 / 50, a quotient of integers that
 /// is a power of two. An implementation using `<` cannot take chi = 1 and
 /// returns chi = 2 instead.
+///
+/// The tie only exists if the backend reaches that quotient without rounding,
+/// which nothing in the spec obliges it to do. So the test asserts it: the
+/// returned trunc_err must equal 0.5 by exact comparison. A backend that
+/// computes epsilon through, say, a squared Frobenius norm lands a fraction of
+/// an ulp away, and that assertion says so directly instead of letting the
+/// retained-chi assertion below fail for an unexplained reason.
 template <typename TenT>
 void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix) {
 #ifndef TCICT_SKIP_TRUNC_SVD
@@ -808,6 +855,7 @@ void test_trunc_svd_target_err_boundary_is_inclusive(tci_test_fixture<TenT> &fix
 
   auto s_shape = tci::shape(ctx, s_diag);
   TCICT_ASSERT(s_shape[0] == 1);
+  TCICT_ASSERT(trunc_err == static_cast<tci::real_t<TenT>>(0.5));
 #else
   (void)fix;
 #endif


### PR DESCRIPTION
## Summary

`trunc_svd`'s general overload — the one taking `chi_min`, `chi_max`, `target_trunc_err` and `s_min` — had no coverage. Every call in `include/tcict/tests/linear_algebra.h` passed two trailing arguments, so `target_trunc_err` was never supplied. The relative truncation error reached the suite only in the other direction, as the `trunc_err` output checked against the [specification](https://tensorcomputingapi.github.io/dev/contents/specification/index.html#tensor-linear-algebra-operations)'s formula.

Nothing therefore pinned how a backend reads the parameter. Taking it as an absolute floor on the singular values, rather than as a bound on the relative discarded weight, left the suite green.

This adds seven tests for the strategy that overload specifies: the `s_min` cutoff, the `chi_min` floor and its refusal to restore values the cutoff removed, the `chi_max` cap, and growth until `epsilon <= target_trunc_err`.

Addresses the `trunc_svd` general-overload gap listed in Phase 5 (#56); the other gaps in that issue are untouched.

## Changes

Seven registered conformance tests, six of them on the shared diagonal fixture with singular values `[3, 2, 1, 0.1]` and one on `[5, 4, 3]`:

- `target_err_selects_chi` — an interior `chi` is selected: `epsilon(2)` meets the target where `epsilon(1)` does not.
- `target_err_scale_invariant` — the same `chi` is selected when every singular value is scaled by `1e-3`, which a threshold on raw singular values cannot reproduce.
- `target_err_chi_min_floor` — `chi_min` forbids a smaller `chi` the target would otherwise allow.
- `target_err_chi_max_cap` — growth stops at `chi_max` with the target unmet.
- `target_err_zero_matches_chi_max_overload` — `chi_min = 1` with `target_trunc_err = 0` reproduces the `(chi_max, s_min)` overload, which V1 defines as exactly that specialization.
- `chi_min_not_restored_below_s_min` — values the `s_min` cutoff discarded are not restored to satisfy `chi_min`: with `s_min` leaving three survivors and `chi_min = 4`, the result is 3.
- `target_err_boundary_is_inclusive` — growth stops as soon as `epsilon` reaches the target: the bounding comparison is `<=`, not `<`. This one uses `[5, 4, 3]`, whose epsilon at `chi = 1` is exactly representable.

Supporting changes in the same header:

- `trunc_svd_expected_epsilon_from` evaluates the specification's epsilon from an explicit spectrum, and `trunc_svd_expected_epsilon` binds it to the shared fixture. Both reimplement the formula on the test side, so an assertion compares the backend against the specification rather than against a second route through the same code. `test_trunc_svd_trunc_err_value` and `test_trunc_svd_trunc_err_bounded` now use the helper instead of an inline literal expression.
- `trunc_svd_expect_retained_chi` carries the call and its two assertions for the five tests that differ only in strategy arguments. The tests stay separate functions because `TCICT_FOREACH_LINEAR_ALGEBRA_TEST_ALL_TYPES` expands one consumer test case per function, so merging them would collapse the per-case reporting and skip granularity that buys.
- `trunc_svd_test_matrix` takes a `scale`, and builds the diagonal from the shared spectrum rather than from four literals.
- The helpers sit inside `TCICT_SKIP_TRUNC_SVD`, so a backend that defines the macro still gets a compilable header.

## Impact

The suite is header-only and consumed by backends as a submodule, so each of the seven functions becomes one test case per element-type variant in every consumer. A backend whose general overload does not implement the strategy turns red on adoption; see Verification for what that looks like on the cytnx backend today.

## Verification

`make integration-test` against a local checkout of [the cytnx backend](https://github.com/r-ccs-cms/tensor-computing-interface-backend-cytnx), across its four element-type lanes `double`, `cdouble`, `float` and `cfloat`.

Two runs, differing only in the backend.

**Backend at `f59751a`, its current `main`,** which reads `target_trunc_err` as an absolute singular-value threshold: **50 cases failed.**

**Backend with a companion branch that implements the strategy: 44 cases failed.** That branch is not published yet — it lands as its own pull request carrying the submodule pin bump, after this one merges — so the green side of this comparison is not independently reproducible today.

The six-case difference is `target_err_selects_chi`, `target_err_scale_invariant` and `target_err_boundary_is_inclusive`, each on both `double` and `cdouble`. That red-to-green transition is the evidence these tests actually constrain the parameter. The other four pass either way, because they pin `chi` through `chi_max`, `chi_min` or `s_min` rather than through the target — they cover the strategy's other clauses, not this defect.

Of the 44 remaining failures, 30 are cases that already fail on `main` of this repository against the same backend, unchanged by this branch: `save` / `load` round-trip and integrity across all four lanes (8), `test_trace_partial` across all four (4), the four existing `trunc_svd` tests on `float` and `cfloat` (8), `test_svd_basic`, `test_svd_reconstruction`, `test_eig_identity` and `test_eigvals_diagonal` on `float` and `cfloat` (8), and `test_to_cplx_inplace` / `test_to_cplx_outofplace` on `float` (2). The other 14 are the seven new tests on the `float` and `cfloat` lanes only. They never reach an assertion: the backend's `trunc_svd` throws on any single-precision input, because it reaches for `Storage.real()` on a singular-value tensor that is already real and that call rejects a non-complex dtype. The four `trunc_svd` tests already on this repository's `main` — `test_trunc_svd`, `test_trunc_svd_trunc_err_value`, `test_trunc_svd_trunc_err_no_truncation` and `test_trunc_svd_trunc_err_bounded` — fail identically on those two lanes, so this is a backend surface those lanes have always hit rather than anything these tests introduce. It does not appear to have a tracking issue on the backend yet. **This branch therefore raises the known-red count by 14, from 30 to 44.** No `double` or `cdouble` `trunc_svd` case fails.

Some runs show one further failure, a `cfloat` matrix-exponential unitarity check unrelated to this branch, tracked in r-ccs-cms/tensor-computing-interface-backend-cytnx#18. The counts above are from runs where it did not fire.

## Notes

`target_err_boundary_is_inclusive` distinguishes `<=` from `<`, which is only observable when the target lands exactly on an achievable epsilon. Rather than write that value as a literal — which would demand a bit pattern the specification does not fix, since it defines epsilon as a formula and constrains no arithmetic path — the test reuses the epsilon the backend reports for a `chi_max`-pinned call as the next call's target. That places the tie on the boundary by construction, but it assumes the value a backend reports in `trunc_err` is the value it compares against `target_trunc_err`. V1 introduces epsilon once and uses that one symbol for both, so this is the specification's own reading; still, a backend that summed the discarded tail for the comparison and took the complement of the retained prefix for the report could land the two an ulp apart and fail here while conforming. The test's docstring records this, and such a backend should compute epsilon once.

The tests read the retained `chi` as `shape(s_diag)[0]`, which holds whether `sigma` is first-order or the second-order `{chi, chi}` diagonal tensor V1 defines. One exception is called out in the source: `target_err_zero_matches_chi_max_overload` reads singular values at a single coordinate, which is valid only while `sigma` is first-order. That read moves with the migration of `sigma` to the second-order form, Phase 4 (#55).
